### PR TITLE
[ENH]: exclude common non-BIDS data sources + evade potential named tuple problem

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -566,18 +566,24 @@ class MetadataIndex(object):
                 an entry already exists.
         """
         if isinstance(f, six.string_types):
-            f = self.layout.get_file(f)
+            filename = self.layout.get_file(f).path
+        elif isinstance(f, tuple):
+            # See http://github.com/grabbles/grabbit/pull/84
+            # .path is not available within File named tuple
+            filename = f.filename
+        else:
+            filename = f
 
-        if f.path in self.file_index and not overwrite:
+        if filename in self.file_index and not overwrite:
             return
 
-        md = self._get_metadata(f.path)
+        md = self._get_metadata(filename)
 
         for md_key, md_val in md.items():
             if md_key not in self.key_index:
                 self.key_index[md_key] = {}
-            self.key_index[md_key][f.path] = md_val
-            self.file_index[f.path][md_key] = md_val
+            self.key_index[md_key][filename] = md_val
+            self.file_index[filename][md_key] = md_val
 
     def _get_metadata(self, path, **kwargs):
         potential_jsons = self.layout._get_nearest_helper(path, '.json',

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -114,7 +114,10 @@ class BIDSLayout(Layout):
                                      "dataset_description.json." % k)
 
         # Determine which subdirectories to exclude from indexing
-        excludes = {"code", "stimuli", "sourcedata", "models", "derivatives"}
+        # A set is extended with non-BIDS-defined common suspects
+        # which are not expected to carry any data of interest
+        excludes = {"code", "stimuli", "sourcedata", "models", "derivatives",
+                    ".git", ".datalad", ".cache", ".workdir", "workdir"}
         if include is not None:
             include = listify(include)
             if "derivatives" in include:

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -69,7 +69,7 @@ class BIDSLayout(Layout):
             was left empty (in which case the root defaults to the file system
             root).
         derivatives (bool, str, list): Specificies whether and/or which
-            derivatives to to index. If True, all pipelines found in the
+            derivatives to index. If True, all pipelines found in the
             derivatives/ subdirectory will be indexed. If a str or list, gives
             the paths to one or more derivatives directories to index. If False
             or None, the derivatives/ directory is ignored during indexing, and


### PR DESCRIPTION
This PR 
- fixes one minor typo, 
- wants to have layout exclude non-bids conform datasources
- wants to have layout extract only the path (instead of using the large self.layout.get_file(f) object) and evade a potential problem with named tuples