### PR TITLE
TEST: Update pytest fixture usage; CI: Allow failures for Python 2.7 pre-release tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,9 @@ matrix:
       env:
         - PYTHON_VERSION=3.6
         - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
+  allow_failures:
+    - python: 2.7
+      env: EXTRA_PIP_FLAGS="--pre --find-links=$EXTRA_WHEELS --find-links $PRE_WHEELS"
 
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/bids/reports/tests/test_parsing.py
+++ b/bids/reports/tests/test_parsing.py
@@ -33,85 +33,72 @@ def testmeta():
     return metadata
 
 
-def test_parsing_anat():
+def test_parsing_anat(testmeta, testconfig):
     """
     parsing.anat_info returns a str description of each structural scan
     """
     type_ = 'T1w'
-    metadata = testmeta()
     img = nib.load(join(get_test_data_path(), 'images/3d.nii.gz'))
-    config = testconfig()
-    desc = parsing.anat_info(type_, metadata, img, config)
+    desc = parsing.anat_info(type_, testmeta, img, testconfig)
     assert isinstance(desc, str)
 
 
-def test_parsing_dwi():
+def test_parsing_dwi(testmeta, testconfig):
     """
     parsing.dwi_info returns a str description of each diffusion scan
     """
     bval_file = join(get_test_data_path(), 'images/4d.bval')
-    metadata = testmeta()
     img = nib.load(join(get_test_data_path(), 'images/4d.nii.gz'))
-    config = testconfig()
-    desc = parsing.dwi_info(bval_file, metadata, img, config)
+    desc = parsing.dwi_info(bval_file, testmeta, img, testconfig)
     assert isinstance(desc, str)
 
 
-def test_parsing_fmap():
+def test_parsing_fmap(testlayout, testmeta, testconfig):
     """
     parsing.fmap_info returns a str decsription of each field map
     """
-    metadata = testmeta()
-    metadata['PhaseEncodingDirection'] = 'j-'
+    testmeta['PhaseEncodingDirection'] = 'j-'
     img = nib.load(join(get_test_data_path(), 'images/3d.nii.gz'))
-    config = testconfig()
-    layout = testlayout()
-    desc = parsing.fmap_info(metadata, img, config, layout)
+    desc = parsing.fmap_info(testmeta, img, testconfig, testlayout)
     assert isinstance(desc, str)
 
 
-def test_parsing_func():
+def test_parsing_func(testmeta, testconfig):
     """
     parsing.func_info returns a str description of a set of functional scans
     grouped by task
     """
-    metadata = testmeta()
     img = nib.load(join(get_test_data_path(), 'images/4d.nii.gz'))
-    config = testconfig()
-    desc = parsing.func_info('nback', 3, metadata, img, config)
+    desc = parsing.func_info('nback', 3, testmeta, img, testconfig)
     assert isinstance(desc, str)
 
 
-def test_parsing_genacq():
+def test_parsing_genacq(testmeta):
     """
     parsing.general_acquisition_info returns a str description of the scanner
     from minimal metadata
     """
-    metadata = testmeta()
-    desc = parsing.general_acquisition_info(metadata)
+    desc = parsing.general_acquisition_info(testmeta)
     assert isinstance(desc, str)
 
 
-def test_parsing_final():
+def test_parsing_final(testmeta):
     """
     parsing.final_paragraph returns a str description of the dicom-to-nifti
     conversion process from minimal metadata
     """
-    metadata = testmeta()
-    desc = parsing.final_paragraph(metadata)
+    desc = parsing.final_paragraph(testmeta)
     assert isinstance(desc, str)
 
 
-def test_parsing_parse():
+def test_parsing_parse(testlayout, testconfig):
     """
     parsing.parse_niftis should return a list of strings, with each string
     containing the description for a single nifti file (except functional data,
     which is combined within task, across runs)
     """
-    layout = testlayout()
     subj = '01'
-    niftis = layout.get(subject=subj, extensions='nii.gz')
-    config = testconfig()
-    desc = parsing.parse_niftis(layout, niftis, subj, config)
+    niftis = testlayout.get(subject=subj, extensions='nii.gz')
+    desc = parsing.parse_niftis(testlayout, niftis, subj, testconfig)
     assert isinstance(desc, list)
     assert isinstance(desc[0], str)

--- a/bids/reports/tests/test_report.py
+++ b/bids/reports/tests/test_report.py
@@ -18,52 +18,52 @@ def testlayout():
     return BIDSLayout(data_dir)
 
 
-def test_report_init():
+def test_report_init(testlayout):
     """Report initialization should return a BIDSReport object.
     """
-    report = BIDSReport(testlayout())
+    report = BIDSReport(testlayout)
     assert isinstance(report, BIDSReport)
 
 
-def test_report_gen():
+def test_report_gen(testlayout):
     """Report generation should return a counter of unique descriptions in the
     dataset.
     """
-    report = BIDSReport(testlayout())
+    report = BIDSReport(testlayout)
     descriptions = report.generate()
     assert isinstance(descriptions, Counter)
 
 
-def test_report_subject():
+def test_report_subject(testlayout):
     """Generating a report for one subject should only return one subject's
     description (i.e., one pattern with a count of one).
     """
-    report = BIDSReport(testlayout())
+    report = BIDSReport(testlayout)
     descriptions = report.generate(subject='01')
     assert sum(descriptions.values()) == 1
 
 
-def test_report_session():
+def test_report_session(testlayout):
     """Generating a report for one session should mean that no other sessions
     appear in any of the unique descriptions.
     """
-    report = BIDSReport(testlayout())
+    report = BIDSReport(testlayout)
     descriptions = report.generate(session='01')
     assert 'session 02' not in ' '.join(descriptions.keys())
 
 
-def test_report_file_config():
+def test_report_file_config(testlayout):
     """Report initialization should take in a config file and use that if
     provided.
     """
     config_file = abspath(join(get_test_data_path(),
                                '../../reports/config/converters.json'))
-    report = BIDSReport(testlayout(), config=config_file)
+    report = BIDSReport(testlayout, config=config_file)
     descriptions = report.generate()
     assert isinstance(descriptions, Counter)
 
 
-def test_report_dict_config():
+def test_report_dict_config(testlayout):
     """Report initialization should take in a config dict and use that if
     provided.
     """
@@ -71,6 +71,6 @@ def test_report_dict_config():
                                '../../reports/config/converters.json'))
     with open(config_file, 'r') as fobj:
         config = json.load(fobj)
-    report = BIDSReport(testlayout(), config=config)
+    report = BIDSReport(testlayout, config=config)
     descriptions = report.generate()
     assert isinstance(descriptions, Counter)


### PR DESCRIPTION
Working off of [Matching Jobs with `allow_failures`](https://docs.travis-ci.com/user/customizing-the-build/#matching-jobs-with-allow_failures).

Closes #276 
Closes #289