### PR TITLE
Fix metadata search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ doc/_build/
 doc/auto_examples/
 doc/gen_modules/
 doc/generated/
+
+# Pytest
+.pytest_cache/

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -544,7 +544,6 @@ class BIDSLayout(Layout):
 
 class MetadataIndex(object):
     """A simple dict-based index for key/value pairs in JSON metadata.
-    
     Args:
         layout (BIDSLayout): The BIDSLayout instance to index.
     """
@@ -566,6 +565,9 @@ class MetadataIndex(object):
             f = self.layout.get_file(f)
 
         if f.path in self.file_index and not overwrite:
+            return
+
+        if 'suffix' not in f.entities: # Skip files without suffixes
             return
 
         md = self._get_metadata(f.path)

--- a/bids/layout/tests/test_metadata_index.py
+++ b/bids/layout/tests/test_metadata_index.py
@@ -71,3 +71,10 @@ def test_search_with_file_constraints(index, layout):
     files = layout.get(subject='03', return_type='file')
     results = index.search(EchoTime=0.017, files=files)
     assert len(results) == 4
+
+def test_search_from_get(index, layout):
+    results = layout.get(EchoTime=0.017, return_type='obj')
+    assert len(results) == 40
+
+    results = layout.get(EchoTime=0.017)
+    assert len(results) == 40

--- a/bids/layout/tests/test_metadata_index.py
+++ b/bids/layout/tests/test_metadata_index.py
@@ -73,8 +73,5 @@ def test_search_with_file_constraints(index, layout):
     assert len(results) == 4
 
 def test_search_from_get(index, layout):
-    results = layout.get(EchoTime=0.017, return_type='obj')
-    assert len(results) == 40
-
     results = layout.get(EchoTime=0.017)
     assert len(results) == 40


### PR DESCRIPTION
This addresses #291 

I actually just realized the core issue of this is related to #281 
The issue is that named tuples have `filename` instead of `path`. Since those are going to be deprecated, I'll update this PR accordingly and merge that branch.

This PR then fixes:

- [x]  Restrict meta-data searches to files w/ suffixes (throws errors on files like `README` otherwise, which can't have meta-data, but are valid BIDS files)
- [x] Add tests for the above scenario, and more generally for searching meta-data directly from `layout.get`)
- [x] Add README to 7t_trt dataset