### PR TITLE
Fix: Set pipeline name to nested dictionary

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -261,7 +261,7 @@ class BIDSLayout(Layout):
         to_check = os.path.relpath(f, self.root)
         if 'derivatives' in self.domains:
             to_check = os.path.join(
-                'derivatives', self.description['PipelineDescription.Name'],
+                'derivatives', self.description['PipelineDescription']['Name'],
                 to_check)
 
         sep = os.path.sep

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -198,7 +198,8 @@ class BIDSLayout(Layout):
             dd = os.path.join(deriv, 'dataset_description.json')
             with open(dd, 'r', encoding='utf-8') as ddfd:
                 description = json.load(ddfd)
-            pipeline_name = description.get('PipelineDescription.Name', None)
+            pipeline_name = description.get(
+                'PipelineDescription', {}).get('Name', None)
             if pipeline_name is None:
                 raise ValueError("Every valid BIDS-derivatives dataset must "
                                 "have a PipelineDescription.Name field set "

--- a/bids/tests/data/ds005/derivatives/events/dataset_description.json
+++ b/bids/tests/data/ds005/derivatives/events/dataset_description.json
@@ -1,5 +1,7 @@
 {
-    "PipelineDescription.Name": "events",
+    "PipelineDescription": {
+        "Name": "events"
+      },
     "BIDSVersion": "1.0.0rc2",
     "License": "This dataset is made available under the Public Domain Dedication and License \nv1.0, whose full text can be found at \nhttp://www.opendatacommons.org/licenses/pddl/1.0/. \nWe hope that all users will follow the ODC Attribution/Share-Alike \nCommunity Norms (http://www.opendatacommons.org/norms/odc-by-sa/); \nin particular, while not legally required, we hope that all users \nof the data will acknowledge the OpenfMRI project and NSF Grant \nOCI-1131441 (R. Poldrack, PI) in any publications.",
     "Name": "Mixed-gambles task",

--- a/bids/tests/data/ds005_derivs/dummy/dataset_description.json
+++ b/bids/tests/data/ds005_derivs/dummy/dataset_description.json
@@ -1,5 +1,7 @@
 {
-    "PipelineDescription.Name": "dummy",
+    "PipelineDescription": {
+        "Name": "dummy"
+      },
     "BIDSVersion": "1.0.0rc2",
     "Name": "Mixed-gambles task -- dummy derivative",
     "ReferencesAndLinks": "Tom, S.M., Fox, C.R., Trepel, C., Poldrack, R.A. (2007). The neural basis of loss aversion in decision-making under risk. Science, 315(5811):515-8"

--- a/bids/tests/data/synthetic/derivatives/fmriprep/dataset_description.json
+++ b/bids/tests/data/synthetic/derivatives/fmriprep/dataset_description.json
@@ -1,5 +1,7 @@
 {
-	"PipelineDescription.Name": "fmriprep",
+	"PipelineDescription": {
+		"Name": "fmriprep"
+	},
 	"Name": "synthetic",
 	"BIDSVersion": "1.0.2",
 	"License": "PD",


### PR DESCRIPTION
`PipelineDescription.Name` should be a nested field, not a flat name. 

Related: https://github.com/poldracklab/fmriprep/issues/1384