### PR TITLE
FIX: Resample dense variables properly in to_df

### DIFF
--- a/bids/variables/kollekshuns.py
+++ b/bids/variables/kollekshuns.py
@@ -270,9 +270,12 @@ class BIDSRunVariableCollection(BIDSVariableCollection):
                 if force_dense and is_numeric_dtype(var.values):
                     _variables[name] = var.to_dense(sampling_rate)
             else:
-                _variables[name] = var.resample(sampling_rate,
-                                                inplace=in_place,
-                                                kind=kind)
+                # None if in_place; no update needed
+                _var = var.resample(sampling_rate,
+                                    inplace=in_place,
+                                    kind=kind)
+                if not in_place:
+                    _variables[name] = _var
 
         if in_place:
             for k, v in _variables.items():

--- a/bids/variables/kollekshuns.py
+++ b/bids/variables/kollekshuns.py
@@ -273,7 +273,6 @@ class BIDSRunVariableCollection(BIDSVariableCollection):
                 _variables[name] = var.resample(sampling_rate,
                                                 inplace=in_place,
                                                 kind=kind)
-                _variables[name] = var
 
         if in_place:
             for k, v in _variables.items():

--- a/bids/variables/variables.py
+++ b/bids/variables/variables.py
@@ -443,7 +443,7 @@ class DenseRunVariable(BIDSVariable):
 
         self.sampling_rate = sampling_rate
 
-    def to_df(self, condition=True, entities=True, timing=True):
+    def to_df(self, condition=True, entities=True, timing=True, sampling_rate=None):
         '''Convert to a DataFrame, with columns for name and entities.
 
         Parameters
@@ -458,6 +458,9 @@ class DenseRunVariable(BIDSVariable):
             If True, includes onset and duration columns (even though events are
             sampled uniformly). If False, omits them.
         '''
+        if sampling_rate not in (None, self.sampling_rate):
+            return self.resample(sampling_rate).to_df(condition, entities)
+
         df = super(DenseRunVariable, self).to_df(condition, entities)
 
         if timing:


### PR DESCRIPTION
Passing `sampling_rate` to `get_design_matrix` currently doesn't resample `DenseRunVariable`s.