### PR TITLE
FIX: Remove deprecated get_header call

### DIFF
--- a/bids/reports/utils.py
+++ b/bids/reports/utils.py
@@ -160,7 +160,7 @@ def get_sizestr(img):
         Field of view string (e.g., '256x256')
     """
     n_x, n_y, n_slices = img.shape[:3]
-    voxel_dims = np.array(img.get_header().get_zooms()[:3])
+    voxel_dims = np.array(img.header.get_zooms()[:3])
     matrix_size = '{0}x{1}'.format(num_to_str(n_x), num_to_str(n_y))
     voxel_size = 'x'.join([num_to_str(s) for s in voxel_dims])
     fov = [n_x, n_y] * voxel_dims[:2]

--- a/bids/version.py
+++ b/bids/version.py
@@ -46,7 +46,7 @@ AUTHOR_EMAIL = "bids-discussion@googlegroups.com"
 PLATFORMS = "OS Independent"
 # No data for now
 REQUIRES = ["grabbit==0.2.5", "six", "num2words", "numpy", "scipy", "pandas",
-            "nibabel", "patsy"]
+            "nibabel>=2.1", "patsy"]
 EXTRAS_REQUIRE = {
    # Just to not break compatibility with externals requiring
    # now deprecated installation schemes


### PR DESCRIPTION
This takes up a lot of space in the Travis output. Nibabel 2.1 is several years old now, so this minimum version should not cause any pain.