### PR TITLE
FIX: numpy.linspace parameter num must be integer

### DIFF
--- a/bids/analysis/hrf.py
+++ b/bids/analysis/hrf.py
@@ -52,7 +52,7 @@ def _gamma_difference_hrf(tr, oversampling=50, time_length=32., onset=0.,
          hrf sampling on the oversampled time grid
     """
     dt = tr / oversampling
-    time_stamps = np.linspace(0, time_length, np.ceil(float(time_length) / dt).astype(np.int))
+    time_stamps = np.linspace(0, time_length, np.rint(float(time_length) / dt).astype(np.int))
     time_stamps -= onset
     hrf = gamma.pdf(time_stamps, delay / dispersion, dt / dispersion) -\
         ratio * gamma.pdf(
@@ -266,7 +266,7 @@ def _sample_condition(exp_condition, frame_times, oversampling=50,
 
     hr_frame_times = np.linspace(frame_times.min() + min_onset,
                                  frame_times.max() * (1 + 1. / (n - 1)),
-                                 np.ceil(n_hr).astype(np.int))
+                                 np.rint(n_hr).astype(np.int))
 
     # Get the condition information
     onsets, durations, values = tuple(map(np.asanyarray, exp_condition))

--- a/bids/analysis/hrf.py
+++ b/bids/analysis/hrf.py
@@ -52,7 +52,7 @@ def _gamma_difference_hrf(tr, oversampling=50, time_length=32., onset=0.,
          hrf sampling on the oversampled time grid
     """
     dt = tr / oversampling
-    time_stamps = np.linspace(0, time_length, float(time_length) / dt)
+    time_stamps = np.linspace(0, time_length, np.ceil(float(time_length) / dt).astype(np.int))
     time_stamps -= onset
     hrf = gamma.pdf(time_stamps, delay / dispersion, dt / dispersion) -\
         ratio * gamma.pdf(
@@ -265,7 +265,8 @@ def _sample_condition(exp_condition, frame_times, oversampling=50,
              min_onset) * oversampling) + 1
 
     hr_frame_times = np.linspace(frame_times.min() + min_onset,
-                                 frame_times.max() * (1 + 1. / (n - 1)), n_hr)
+                                 frame_times.max() * (1 + 1. / (n - 1)),
+                                 np.ceil(n_hr).astype(np.int))
 
     # Get the condition information
     onsets, durations, values = tuple(map(np.asanyarray, exp_condition))


### PR DESCRIPTION
`np.ceil` is a conservative interpretation of a float for number of elements to create with `linspace`, ensuring an oversampling rate of at least that specified. If approximate is all that's needed, then `floor` might save a little computation, and `rint` would be the best approximation.