### PR TITLE
Support pathlib.Path and other Str-castable types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ before_install:
     - python --version # just to check
     - travis_retry pip install -U pip wheel  # needed at one point
     - travis_retry pip install pytest pytest-xdist pytest-cov codecov
+    - travis_retry pip install pathlib
 
 install:
 - pip install $EXTRA_PIP_FLAGS ".[analysis]"

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import json
 import warnings
 from io import open
@@ -119,9 +120,9 @@ class BIDSLayout(Layout):
                 assert isinstance(root, pathlib.Path)
                 # the os functions can only handle pathlib.Paths from 3.4 when it joined
                 # the standard library
-                if not six.PY34:
+                if sys.version_info < (3,6):
                     raise TypeError("root argument is pathlib.Path-derived, "
-                            "this type is only supported on python>=3.4")
+                            "this type is only supported on python>=3.6")
             except (ImportError, AssertionError):
                 # there's only one import statement and one assertion above, so this
                 # situation is pretty unambiguous

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -139,11 +139,11 @@ class BIDSLayout(Layout):
             try:
                 root = str(root)
             except:
-                raise ValueError("root argument must be a string (or a type that "
+                raise TypeError("root argument must be a string (or a type that "
                         "supports casting to string, such as pathlib.Path)"
                         " specifying the directory containing the BIDS dataset.")
-                if not os.path.exists(root):
-                    raise ValueError("BIDS root does not exist: %s" % root)
+        if not os.path.exists(root):
+            raise ValueError("BIDS root does not exist: %s" % root)
 
         self.root = root
 

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -122,12 +122,11 @@ class BIDSLayout(Layout):
                 if not six.PY34:
                     raise TypeError("root argument is pathlib.Path-derived, "
                             "this type is only supported on python>=3.4")
-                del pathlib
             except (ImportError, AssertionError):
                 # there's only one import statement and one assertion above, so this
                 # situation is pretty unambiguous
-                raise ValueError("root argument must be a string specifying the"
-                                 " directory containing the BIDS dataset.")
+                raise ValueError("root argument must be a string or pathlib.Path"
+                        " specifying the directory containing the BIDS dataset.")
             except:
                 raise
         if not os.path.exists(root):

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -114,24 +114,16 @@ class BIDSLayout(Layout):
 
         # Validate arguments
         if not isinstance(root, six.string_types):
-            # attempt to handle pathlib paths before giving up
+            # attempt to handle pathlib paths (or other types that can be cast as str)
+            # before giving up
             try:
-                import pathlib
-                assert isinstance(root, pathlib.Path)
-                # the os functions can only handle pathlib.Paths from 3.4 when it joined
-                # the standard library
-                if sys.version_info < (3,6):
-                    raise TypeError("root argument is pathlib.Path-derived, "
-                            "this type is only supported on python>=3.6")
-            except (ImportError, AssertionError):
-                # there's only one import statement and one assertion above, so this
-                # situation is pretty unambiguous
-                raise ValueError("root argument must be a string or pathlib.Path"
-                        " specifying the directory containing the BIDS dataset.")
+                root = str(root)
             except:
-                raise
-        if not os.path.exists(root):
-            raise ValueError("BIDS root does not exist: %s" % root)
+                raise ValueError("root argument must be a string (or a type that "
+                        "supports casting to string, such as pathlib.Path)"
+                        " specifying the directory containing the BIDS dataset.")
+                if not os.path.exists(root):
+                    raise ValueError("BIDS root does not exist: %s" % root)
 
         self.root = root
 

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -113,8 +113,23 @@ class BIDSLayout(Layout):
 
         # Validate arguments
         if not isinstance(root, six.string_types):
-            raise ValueError("root argument must be a string specifying the"
-                             " directory containing the BIDS dataset.")
+            # attempt to handle pathlib paths before giving up
+            try:
+                import pathlib
+                assert isinstance(root, pathlib.Path)
+                # the os functions can only handle pathlib.Paths from 3.4 when it joined
+                # the standard library
+                if not six.PY34:
+                    raise TypeError("root argument is pathlib.Path-derived, "
+                            "this type is only supported on python>=3.4")
+                del pathlib
+            except (ImportError, AssertionError):
+                # there's only one import statement and one assertion above, so this
+                # situation is pretty unambiguous
+                raise ValueError("root argument must be a string specifying the"
+                                 " directory containing the BIDS dataset.")
+            except:
+                raise
         if not os.path.exists(root):
             raise ValueError("BIDS root does not exist: %s" % root)
 

--- a/bids/layout/tests/test_rootpath.py
+++ b/bids/layout/tests/test_rootpath.py
@@ -20,23 +20,23 @@ def test_strroot_neg():
     with pytest.raises(ValueError):
         layout = BIDSLayout(FALSESTR)
 
-@pytest.mark.skipif(sys.version_info < (3,4),
-        reason="requires python3.4 or higher")
+@pytest.mark.skipif(sys.version_info < (3,6),
+        reason="requires python3.6 or higher")
 def test_pathroot_pos():
     layout = BIDSLayout(TESTPATH)
 
-@pytest.mark.skipif(sys.version_info < (3,4),
-        reason="requires python3.4 or higher")
+@pytest.mark.skipif(sys.version_info < (3,6),
+        reason="requires python3.6 or higher")
 def test_pathroot_neg():
     with pytest.raises(ValueError):
         layout = BIDSLayout(FALSEPATH)
 
-@pytest.mark.skipif(sys.version_info >= (3,4), reason="test of exception handling for older pythons")
+@pytest.mark.skipif(sys.version_info >= (3,6), reason="test of exception handling for older pythons")
 def test_pathroot_pos_oldpython():
     with pytest.raises(TypeError):
         layout = BIDSLayout(TESTPATH)
 
-@pytest.mark.skipif(sys.version_info >= (3,4), reason="test of exception handling for older pythons")
+@pytest.mark.skipif(sys.version_info >= (3,6), reason="test of exception handling for older pythons")
 def test_pathroot_neg_oldpython():
     with pytest.raises(TypeError):
         layout = BIDSLayout(FALSEPATH)

--- a/bids/layout/tests/test_rootpath.py
+++ b/bids/layout/tests/test_rootpath.py
@@ -20,23 +20,9 @@ def test_strroot_neg():
     with pytest.raises(ValueError):
         layout = BIDSLayout(FALSESTR)
 
-@pytest.mark.skipif(sys.version_info < (3,6),
-        reason="requires python3.6 or higher")
 def test_pathroot_pos():
     layout = BIDSLayout(TESTPATH)
 
-@pytest.mark.skipif(sys.version_info < (3,6),
-        reason="requires python3.6 or higher")
 def test_pathroot_neg():
     with pytest.raises(ValueError):
-        layout = BIDSLayout(FALSEPATH)
-
-@pytest.mark.skipif(sys.version_info >= (3,6), reason="test of exception handling for older pythons")
-def test_pathroot_pos_oldpython():
-    with pytest.raises(TypeError):
-        layout = BIDSLayout(TESTPATH)
-
-@pytest.mark.skipif(sys.version_info >= (3,6), reason="test of exception handling for older pythons")
-def test_pathroot_neg_oldpython():
-    with pytest.raises(TypeError):
         layout = BIDSLayout(FALSEPATH)

--- a/bids/tests/test_rootpath.py
+++ b/bids/tests/test_rootpath.py
@@ -1,0 +1,42 @@
+import sys
+import pytest
+from pathlib import Path
+from bids.layout import BIDSLayout
+from bids.tests import get_test_data_path
+"""
+test handling of pathlib Path file paths in place of old-style string type
+"""
+
+TESTPATH = Path(get_test_data_path()).joinpath("ds005")
+TESTSTR = str(TESTPATH)
+FALSEPATH = TESTPATH.joinpath("junk")
+FALSESTR = str(FALSEPATH)
+assert not FALSEPATH.exists()
+
+def test_strroot_pos():
+    layout = BIDSLayout(TESTSTR)
+
+def test_strroot_neg():
+    with pytest.raises(ValueError):
+        layout = BIDSLayout(FALSESTR)
+
+@pytest.mark.skipif(sys.version_info < (3,4),
+        reason="requires python3.4 or higher")
+def test_pathroot_pos():
+    layout = BIDSLayout(TESTPATH)
+
+@pytest.mark.skipif(sys.version_info < (3,4),
+        reason="requires python3.4 or higher")
+def test_pathroot_neg():
+    with pytest.raises(ValueError):
+        layout = BIDSLayout(FALSEPATH)
+
+@pytest.mark.skipif(sys.version_info >= (3,4), reason="test of exception handling for older pythons")
+def test_pathroot_pos_oldpython():
+    with pytest.raises(TypeError):
+        layout = BIDSLayout(TESTPATH)
+
+@pytest.mark.skipif(sys.version_info >= (3,4), reason="test of exception handling for older pythons")
+def test_pathroot_neg_oldpython():
+    with pytest.raises(TypeError):
+        layout = BIDSLayout(FALSEPATH)

--- a/bids/version.py
+++ b/bids/version.py
@@ -52,7 +52,7 @@ EXTRAS_REQUIRE = {
    # now deprecated installation schemes
    'analysis': []
 }
-TESTS_REQUIRE = ["pytest>=3.3.0", "pathlib; python_version < \"3.4\""]
+TESTS_REQUIRE = ["pytest>=3.3.0", 'pathlib; python_version < "3.4"']
 
 
 def package_files(directory):

--- a/bids/version.py
+++ b/bids/version.py
@@ -52,7 +52,7 @@ EXTRAS_REQUIRE = {
    # now deprecated installation schemes
    'analysis': []
 }
-TESTS_REQUIRE = ["pytest>=3.3.0"]
+TESTS_REQUIRE = ["pytest>=3.3.0", "pathlib"]
 
 
 def package_files(directory):

--- a/bids/version.py
+++ b/bids/version.py
@@ -52,7 +52,7 @@ EXTRAS_REQUIRE = {
    # now deprecated installation schemes
    'analysis': []
 }
-TESTS_REQUIRE = ["pytest>=3.3.0", "pathlib"]
+TESTS_REQUIRE = ["pytest>=3.3.0", "pathlib ; python_version < 3.4"]
 
 
 def package_files(directory):

--- a/bids/version.py
+++ b/bids/version.py
@@ -52,7 +52,7 @@ EXTRAS_REQUIRE = {
    # now deprecated installation schemes
    'analysis': []
 }
-TESTS_REQUIRE = ["pytest>=3.3.0", "pathlib ; python_version < 3.4"]
+TESTS_REQUIRE = ["pytest>=3.3.0", "pathlib; python_version < \"3.4\""]
 
 
 def package_files(directory):


### PR DESCRIPTION
Pathlib is great, and works out of the box in pybids on python 3.4+. I only had to tweak the argument validation slightly.