### PR TITLE
ENH: Resample design matrix to 1/TR by default

### DIFF
--- a/bids/analysis/analysis.py
+++ b/bids/analysis/analysis.py
@@ -219,7 +219,7 @@ class Step(object):
             self.output_nodes.append(node)
 
     def get_design_matrix(self, names=None, format='long', mode='both',
-                          force=False, **kwargs):
+                          force=False, sampling_rate='TR', **kwargs):
         ''' Get design matrix and associated information.
 
         Args:
@@ -239,6 +239,13 @@ class Step(object):
                 be converted to dense variables and included in the returned
                 design matrix in the .dense attribute. The force argument is
                 ignored entirely if mode='both'.
+            sampling_rate ('TR', 'highest' or float): Sampling rate at which to
+                generate the dense design matrix. When 'TR', the repetition
+                time is used, if available, to select the sampling rate (1/TR).
+                When 'highest', all variables are resampled to the highest
+                sampling rate of any variable. The sampling rate may also be
+                specified explicitly in Hz. Has no effect on sparse design
+                matrices.
             kwargs: Optional keyword arguments. Includes (1) selectors used
                 to constrain which of the available nodes get returned
                 (e.g., passing subject=['01', '02'] will return design
@@ -253,7 +260,8 @@ class Step(object):
         '''
         nodes, kwargs = self._filter_objects(self.output_nodes, kwargs)
         return [n.get_design_matrix(names, format, mode=mode, force=force,
-                                    **kwargs) for n in nodes]
+                                    sampling_rate=sampling_rate, **kwargs)
+                for n in nodes]
 
     def get_contrasts(self, names=None, variables=None, **kwargs):
         ''' Return contrast information for the current block.
@@ -346,11 +354,12 @@ class AnalysisNode(object):
                 design matrix in the .dense attribute. The force argument is
                 ignored entirely if mode='both'.
             sampling_rate ('TR', 'highest' or float): Sampling rate at which to
-                generate the design matrix. When 'TR', the repetition time is
-                used, if available, to select the sampling rate (1/TR). When
-                'highest', all variables are resampled to the highest sampling
-                rate of any variable. The sampling rate may also be specified
-                explicitly in Hz.
+                generate the dense design matrix. When 'TR', the repetition
+                time is used, if available, to select the sampling rate (1/TR).
+                When 'highest', all variables are resampled to the highest
+                sampling rate of any variable. The sampling rate may also be
+                specified explicitly in Hz. Has no effect on sparse design
+                matrices.
             kwargs: Optional keyword arguments to pass onto each Variable's
                 to_df() call (e.g., sampling_rate, entities, timing, etc.).
 

--- a/bids/analysis/analysis.py
+++ b/bids/analysis/analysis.py
@@ -103,7 +103,7 @@ class Step(object):
         layout (BIDSLayout): The BIDSLayout containing all project files.
         level (str): The BIDS keyword to use as the grouping variable; must be
             one of ['run', 'session', 'subject', or 'dataset'].
-        index (int): The numerical index of the current Block within the
+        index (int): The numerical index of the current Step within the
             sequence of steps.
         name (str): Optional name to assign to the block. Must be specified
             in order to enable name-based indexing in the parent Analysis.
@@ -112,7 +112,7 @@ class Step(object):
         contrasts (list): List of contrasts to apply to the parameter estimates
             generated when the model is fit.
         input_nodes (list): Optional list of AnalysisNodes to use as input to
-            this Block (typically, the output from the preceding Block).
+            this Step (typically, the output from the preceding Step).
         auto_contrasts (list, bool): Optional list of variable names to create
             an indicator contrast for. Alternatively, if the boolean value True
             is passed, a contrast is automatically generated for _all_
@@ -145,7 +145,7 @@ class Step(object):
 
     def _group_objects(self, objects):
         # Group list of objects into bins defined by all entities at current
-        # Block level or higher.
+        # Step level or higher.
         if self.level == 'dataset':
             return [objects]
         groups = OrderedDict()
@@ -171,12 +171,12 @@ class Step(object):
         return BIDSVariableCollection.from_df(data, entities, self.level)
 
     def setup(self, input_nodes=None, **kwargs):
-        ''' Set up the Block and construct the design matrix.
+        ''' Set up the Step and construct the design matrix.
 
         Args:
             input_nodes (list): Optional list of Node objects produced by
-                the preceding Block in the analysis. If None, uses any inputs
-                passed in at Block initialization.
+                the preceding Step in the analysis. If None, uses any inputs
+                passed in at Step initialization.
             kwargs: Optional keyword arguments to pass onto load_variables.
         '''
         self.output_nodes = []
@@ -297,14 +297,14 @@ ContrastInfo = namedtuple('ContrastInfo', ('name', 'weights', 'type',
 
 
 class AnalysisNode(object):
-    ''' A single analysis node generated within a Block.
+    ''' A single analysis node generated within a Step.
 
     Args:
         level (str): The level of the Node. Most be one of 'run', 'session',
             'subject', or 'dataset'.
         collection (BIDSVariableCollection): The BIDSVariableCollection
             containing variables at this Node.
-        contrasts (list): A list of contrasts defined in the originating Block.
+        contrasts (list): A list of contrasts defined in the originating Step.
         auto_contrasts (list): Optional list of variable names to create
             an indicator contrast for. Alternatively, if the boolean value True
             is passed, a contrast is automatically generated for _all_

--- a/bids/analysis/tests/test_analysis.py
+++ b/bids/analysis/tests/test_analysis.py
@@ -39,17 +39,27 @@ def test_get_design_matrix_arguments(analysis):
     assert result.sparse is None
     assert result.dense is None
 
-    kwargs = dict(run=1, subject='01', mode='dense', force=True)
+    kwargs = dict(run=1, subject='01', mode='dense', force=True, sampling_rate='highest')
     result = analysis['run'].get_design_matrix(**kwargs)[0]
     assert result.sparse is None
     assert result.dense.shape == (4800, 6)
+
+    kwargs = dict(run=1, subject='01', mode='dense', force=True, sampling_rate='TR')
+    result = analysis['run'].get_design_matrix(**kwargs)[0]
+    assert result.sparse is None
+    assert result.dense.shape == (240, 6)
+
+    kwargs = dict(run=1, subject='01', mode='dense', force=True, sampling_rate=0.5)
+    result = analysis['run'].get_design_matrix(**kwargs)[0]
+    assert result.sparse is None
+    assert result.dense.shape == (240, 6)
 
     # format='long' should be ignored for dense output
     kwargs = dict(run=1, subject='01', mode='dense', force=True,
                   format='long', entities=False)
     result = analysis['run'].get_design_matrix(**kwargs)[0]
     assert result.sparse is None
-    assert result.dense.shape == (4800, 1)
+    assert result.dense.shape == (240, 1)
 
     kwargs = dict(run=1, subject='01', mode='sparse', format='wide',
                   entities=False)


### PR DESCRIPTION
Not quite #288, but achieves in the common case the goal aimed at by having an `Analysis.get_tr()`, which is to establish the sampling rate to be passed to `get_design_matrix`.

Also establishes the rough method for pulling out the TR from series of `AnalysisNode`s, which will be useful in implementing that functionality.