### PR TITLE
repair travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## PyBIDS
-[![Build Status (Linux and OS X)](https://travis-ci.org/INCF/pybids.svg?branch=master)](https://travis-ci.org/bids-standard/pybids)
+[![Build Status (Linux and OS X)](https://travis-ci.org/bids-standard/pybids.svg?branch=master)](https://travis-ci.org/bids-standard/pybids)
 [![Build Status (Windows)](https://ci.appveyor.com/api/projects/status/5aa4c6e3m15ew4v7?svg=true)](https://ci.appveyor.com/project/chrisfilo/pybids-ilb80)
 [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/bids-standard/pybids/master)
 


### PR DESCRIPTION
updating an old INCF reference in the link to bids-standard to fix the "build unknown" of the travis badge.