### PR TITLE
Allow extra configuration files through module level config

### DIFF
--- a/bids/config.py
+++ b/bids/config.py
@@ -11,7 +11,12 @@ __all__ = ['set_option', 'set_options', 'get_option']
 
 _config_name = 'pybids_config.json'
 
-_default_settings = {}
+conf_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                         'layout', 'config', '%s.json')
+_default_settings = {
+    'config_paths': {
+        name: conf_path.format(name) for name in ['bids', 'derivatives']}
+}
 
 
 def set_option(key, value):

--- a/bids/config.py
+++ b/bids/config.py
@@ -12,7 +12,7 @@ __all__ = ['set_option', 'set_options', 'get_option']
 _config_name = 'pybids_config.json'
 
 conf_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                         'layout', 'config', '%s.json')
+                         'layout', 'config', '{}.json')
 _default_settings = {
     'config_paths': {
         name: conf_path.format(name) for name in ['bids', 'derivatives']}

--- a/bids/layout/__init__.py
+++ b/bids/layout/__init__.py
@@ -1,3 +1,3 @@
-from .layout import BIDSLayout
+from .layout import BIDSLayout, add_config_paths
 from .validation import BIDSValidator
-__all__ = ["BIDSLayout", "BIDSValidator"]
+__all__ = ["BIDSLayout", "BIDSValidator", "add_config_paths"]

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -40,8 +40,8 @@ def add_config_paths(**kwargs):
             raise ValueError(
                 'Configuration file "{}" does not exist'.format(k))
 
-    cf.set_option(
-        'config_paths', {**kwargs, **cf.get_option('config_paths')})
+    kwargs.update(**cf.get_option('config_paths'))
+    cf.set_option('config_paths', kwargs)
 
 
 class BIDSFile(File):

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -148,8 +148,7 @@ class BIDSLayout(Layout):
         if config is None:
             config = 'bids'
         config_paths = get_option('config_paths')
-        bids_conf = [config_paths[c] for c in listify(config)]
-        path = (root, bids_conf)
+        path = (root, [config_paths[c] for c in listify(config)])
 
         # Initialize grabbit Layout
         super(BIDSLayout, self).__init__(path, root=self.root,

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -122,14 +122,17 @@ class BIDSLayout(Layout):
 
         target = os.path.join(self.root, 'dataset_description.json')
         if not os.path.exists(target):
-            raise ValueError(
-                "'dataset_description.json' file is missing from project root."
-                " Every valid BIDS dataset must have this file.")
+            if validate is True:
+                raise ValueError(
+                    "'dataset_description.json' is missing from project root."
+                    " Every valid BIDS dataset must have this file.")
+            else:
+                self.description = None
         else:
             with open(target, 'r', encoding='utf-8') as desc_fd:
                 self.description = json.load(desc_fd)
             for k in ['Name', 'BIDSVersion']:
-                if k not in self.description:
+                if k not in self.description and validate is True:
                     raise ValueError("Mandatory '%s' field missing from "
                                      "dataset_description.json." % k)
 

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -1,4 +1,5 @@
 import os
+import re
 import json
 import warnings
 from io import open
@@ -10,8 +11,7 @@ import nibabel as nb
 from collections import defaultdict
 from functools import reduce, partial
 from itertools import chain
-import re
-
+from bids.config import get_option
 
 try:
     from os.path import commonpath
@@ -122,9 +122,9 @@ class BIDSLayout(Layout):
 
         target = os.path.join(self.root, 'dataset_description.json')
         if not os.path.exists(target):
-            raise ValueError("'dataset_description.json' file is missing from "
-                          "project root. Every valid BIDS dataset must have "
-                          "this file.")
+            raise ValueError(
+                "'dataset_description.json' file is missing from project root."
+                " Every valid BIDS dataset must have this file.")
         else:
             with open(target, 'r', encoding='utf-8') as desc_fd:
                 self.description = json.load(desc_fd)
@@ -147,10 +147,8 @@ class BIDSLayout(Layout):
         # Set up path and config for grabbit
         if config is None:
             config = 'bids'
-        config = listify(config)
-        conf_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                                 'config', '%s.json')
-        bids_conf = [conf_path % c for c in config]
+        config_paths = get_option('config_paths')
+        bids_conf = [config_paths[c] for c in listify(config)]
         path = (root, bids_conf)
 
         # Initialize grabbit Layout
@@ -162,11 +160,11 @@ class BIDSLayout(Layout):
         # Add derivatives if any are found
         self.derivatives = {}
         if derivatives:
-            if derivatives == True:
+            if derivatives is True:
                 derivatives = os.path.join(root, 'derivatives')
             self.add_derivatives(
                 derivatives, validate=validate,
-                index_associated=index_associated,include=include,
+                index_associated=index_associated, include=include,
                 absolute_paths=absolute_paths, derivatives=None, config=None,
                 sources=self, **kwargs)
 

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -4,6 +4,7 @@ import json
 import warnings
 from io import open
 from .validation import BIDSValidator
+from .. import config as cf
 from grabbit import Layout, File
 from grabbit.external import six, inflect
 from grabbit.utils import listify
@@ -24,6 +25,23 @@ except ImportError:
 
 
 __all__ = ['BIDSLayout']
+
+
+def add_config_paths(**kwargs):
+    """ Add to the pool of available configuration files for BIDSLayout.
+    Args:
+        kwargs: each kwarg should be a pair of config key name, and path
+
+    Example: bids.layout.add_config_paths(my_config='/path/to/config')
+    """
+
+    for k, path in kwargs.items():
+        if not os.path.exists(path):
+            raise ValueError(
+                'Configuration file "{}" does not exist'.format(k))
+
+    cf.set_option(
+        'config_paths', {**kwargs, **cf.get_option('config_paths')})
 
 
 class BIDSFile(File):

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -57,7 +57,7 @@ class BIDSFile(File):
         """
         try:
             return nb.load(self.path)
-        except Exception as e:
+        except Exception:
             return None
 
     @property
@@ -208,8 +208,8 @@ class BIDSLayout(Layout):
                 'PipelineDescription', {}).get('Name', None)
             if pipeline_name is None:
                 raise ValueError("Every valid BIDS-derivatives dataset must "
-                                "have a PipelineDescription.Name field set "
-                                "inside dataset_description.json.")
+                                 "have a PipelineDescription.Name field set "
+                                 "inside dataset_description.json.")
             if pipeline_name in self.derivatives:
                 raise ValueError("Pipeline name '%s' has already been added "
                                  "to this BIDSLayout. Every added pipeline "
@@ -220,13 +220,15 @@ class BIDSLayout(Layout):
             self.derivatives[pipeline_name] = BIDSLayout(deriv, **kwargs)
 
             # Propagate derivative entities into top-level dynamic getters
-            deriv_entities = set(ent.name
-                                 for ent in self.derivatives[pipeline_name].entities.values())
+            deriv_entities = set(
+                ent.name
+                for ent in self.derivatives[pipeline_name].entities.values())
             for deriv_ent in deriv_entities - local_entities:
                 local_entities.add(deriv_ent)
                 getter = 'get_' + inflect.engine().plural(deriv_ent)
                 if not hasattr(self, getter):
-                    func = partial(self.get, target=deriv_ent, return_type='id')
+                    func = partial(
+                        self.get, target=deriv_ent, return_type='id')
                     setattr(self, getter, func)
 
     def to_df(self, **kwargs):
@@ -299,9 +301,9 @@ class BIDSLayout(Layout):
                 )
             suffix = f.entities['suffix']
 
-        tmp = self.get_nearest(path, extensions=extension, all_=True,
-                               suffix=suffix, ignore_strict_entities=['suffix'],
-                               **kwargs)
+        tmp = self.get_nearest(
+            path, extensions=extension, all_=True, suffix=suffix,
+            ignore_strict_entities=['suffix'], **kwargs)
 
         if len(tmp):
             return tmp
@@ -346,10 +348,11 @@ class BIDSLayout(Layout):
                 only files that match the first two subjects.
 
         Returns:
-            A list of BIDSFile (default) or other (see return_type for details) objects.
+            A list of BIDSFile (default) or other objects
+            (see return_type for details).
         """
 
-        if derivatives == True:
+        if derivatives is True:
             derivatives = list(self.derivatives.keys())
         elif derivatives:
             derivatives = listify(derivatives)
@@ -441,7 +444,6 @@ class BIDSLayout(Layout):
 
         results.update(self.metadata_index.file_index[path])
         return results
-
 
     def get_bvec(self, path, **kwargs):
         """Get bvec file for passed path."""
@@ -598,7 +600,7 @@ class MetadataIndex(object):
         if f.path in self.file_index and not overwrite:
             return
 
-        if 'suffix' not in f.entities: # Skip files without suffixes
+        if 'suffix' not in f.entities:  # Skip files without suffixes
             return
 
         md = self._get_metadata(f.path)

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -132,9 +132,10 @@ class BIDSLayout(Layout):
             with open(target, 'r', encoding='utf-8') as desc_fd:
                 self.description = json.load(desc_fd)
             for k in ['Name', 'BIDSVersion']:
-                if k not in self.description and validate is True:
-                    raise ValueError("Mandatory '%s' field missing from "
-                                     "dataset_description.json." % k)
+                if validate is True:
+                    if k not in self.description:
+                        raise ValueError("Mandatory '%s' field missing from "
+                                         "dataset_description.json." % k)
 
         # Determine which subdirectories to exclude from indexing
         excludes = {"code", "stimuli", "sourcedata", "models", "derivatives"}

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -39,6 +39,8 @@ def add_config_paths(**kwargs):
         if not os.path.exists(path):
             raise ValueError(
                 'Configuration file "{}" does not exist'.format(k))
+        if k in cf.get_option('config_paths'):
+            raise ValueError('Configuration {!r} already exists'.format(k))
 
     kwargs.update(**cf.get_option('config_paths'))
     cf.set_option('config_paths', kwargs)

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -149,8 +149,8 @@ class BIDSLayout(Layout):
         else:
             with open(target, 'r', encoding='utf-8') as desc_fd:
                 self.description = json.load(desc_fd)
-            for k in ['Name', 'BIDSVersion']:
-                if validate is True:
+            if validate is True:
+                for k in ['Name', 'BIDSVersion']:
                     if k not in self.description:
                         raise ValueError("Mandatory '%s' field missing from "
                                          "dataset_description.json." % k)


### PR DESCRIPTION
Closes #312 

I did this in the simplest way possible that went with the `bids.config` mechanism we already have in place.

To specify a new config file you would so something like:


```
from bids import config
cf.set_option('config_paths', {'myextra': 'mypath', **cf.get_option('config_paths')})
print(cf.get_option('config_paths'))
 
> {'myextra': 'mypath',
>  'bids': '/home/zorro/repos/pybids/bids/layout/config/bids.json',
> 'derivatives': '/home/zorro/repos/pybids/bids/layout/config/derivatives.json'}
```

I think that's self explanatory enough for the rare situation people need to do this, and also cleans up `BIDSLayout's` code a bit. We could add a convenience function that appends to the config in a cleaner form if we wanted. 
