### PR TITLE
RF: Delay imports to reduce load time

### DIFF
--- a/bids/analysis/analysis.py
+++ b/bids/analysis/analysis.py
@@ -7,7 +7,6 @@ from . import transformations as transform
 from collections import namedtuple, OrderedDict
 from six import string_types
 import numpy as np
-import pandas as pd
 from itertools import chain
 
 
@@ -160,6 +159,7 @@ class Step(object):
         return list(groups.values())
 
     def _concatenate_input_nodes(self, nodes):
+        import pandas as pd
         data, entities = [], []
         for n in nodes:
             contrasts = [c.name for c in n.contrasts]
@@ -459,6 +459,7 @@ class AnalysisNode(object):
             contrasts = [c for c in contrasts if c['name'] in names]
 
         def setup_contrast(c):
+            import pandas as pd
             weights = np.atleast_2d(c['weights'])
             weights = pd.DataFrame(weights, columns=c['condition_list'])
             # If variables were explicitly passed, use them as the columns

--- a/bids/analysis/hrf.py
+++ b/bids/analysis/hrf.py
@@ -8,7 +8,6 @@ Author: Bertrand Thirion, 2011--2015
 
 import warnings
 import numpy as np
-from scipy.stats import gamma
 
 
 def _gamma_difference_hrf(tr, oversampling=50, time_length=32., onset=0.,
@@ -51,6 +50,7 @@ def _gamma_difference_hrf(tr, oversampling=50, time_length=32., onset=0.,
     hrf : array of shape(length / tr * oversampling, dtype=float)
          hrf sampling on the oversampled time grid
     """
+    from scipy.stats import gamma
     dt = tr / oversampling
     time_stamps = np.linspace(0, time_length, np.rint(float(time_length) / dt).astype(np.int))
     time_stamps -= onset

--- a/bids/analysis/transformations/base.py
+++ b/bids/analysis/transformations/base.py
@@ -1,7 +1,6 @@
 ''' Base Transformation class and associated utilities. '''
 
 import numpy as np
-import pandas as pd
 from bids.utils import listify
 import warnings
 from abc import ABCMeta, abstractmethod
@@ -263,6 +262,7 @@ class Transformation(object):
             if self._return_type in ['none', None]:
                 continue
             elif self._return_type == 'numpy':
+                import pandas as pd
                 col.values = pd.DataFrame(result)
             elif self._return_type == 'pandas':
                 col.values = result

--- a/bids/analysis/transformations/compute.py
+++ b/bids/analysis/transformations/compute.py
@@ -3,7 +3,6 @@ Transformations that primarily involve numerical computation on variables.
 '''
 
 import numpy as np
-import pandas as pd
 from bids.utils import listify
 from .base import Transformation
 from bids.analysis import hrf
@@ -70,6 +69,7 @@ class Orthogonalize(Transformation):
     _align = ('other')
 
     def _transform(self, var, other):
+        import pandas as pd
 
         other = listify(other)
 
@@ -93,6 +93,7 @@ class Product(Transformation):
     _output_required = True
 
     def _transform(self, data):
+        import pandas as pd
         data = pd.concat(data, axis=1, sort=True)
         return data.product(1)
 
@@ -131,6 +132,7 @@ class Sum(Transformation):
     _output_required = True
 
     def _transform(self, data, weights=None):
+        import pandas as pd
         data = pd.concat(data, axis=1, sort=True)
         if weights is None:
             weights = np.ones(data.shape[1])
@@ -191,6 +193,7 @@ class And(Transformation):
     _output_required = True
 
     def _transform(self, dfs):
+        import pandas as pd
         df = pd.concat(dfs, axis=1, sort=True)
         return df.all(axis=1).astype(int)
 
@@ -221,5 +224,6 @@ class Or(Transformation):
     _output_required = True
 
     def _transform(self, dfs):
+        import pandas as pd
         df = pd.concat(dfs, axis=1, sort=True)
         return df.any(axis=1).astype(int)

--- a/bids/analysis/transformations/munge.py
+++ b/bids/analysis/transformations/munge.py
@@ -4,10 +4,8 @@ other formats or shapes.
 '''
 
 import numpy as np
-import pandas as pd
 from bids.utils import listify
 from .base import Transformation
-from patsy import dmatrix
 import re
 from bids.variables import DenseRunVariable, SimpleVariable
 
@@ -108,7 +106,7 @@ class Factor(Transformation):
     _allow_categorical = ('variables',)
 
     def _transform(self, var, constraint='none', ref_level=None, sep='.'):
-
+        import pandas as pd
         result = []
         data = var.to_df()
         orig_name = var.name
@@ -153,6 +151,7 @@ class Filter(Transformation):
     _allow_categorical = ('variables', 'by')
 
     def _transform(self, var, query, by=None):
+        import pandas as pd
 
         if by is None:
             by = []
@@ -208,6 +207,7 @@ class Replace(Transformation):
     _allow_categorical = ('variables',)
 
     def _transform(self, var, replace, attribute='value'):
+        import pandas as pd
 
         if attribute == 'value':
             var.values = var.values.replace(replace)
@@ -255,6 +255,7 @@ class Split(Transformation):
     _densify = ('variables', 'by')
 
     def _transform(self, var, by, drop_orig=True):
+        import pandas as pd
 
         if not isinstance(var, SimpleVariable):
             self._densify_variables()
@@ -283,6 +284,7 @@ class Split(Transformation):
         # For dense data, use patsy to create design matrix, then multiply
         # it by target variable
         else:
+            from patsy import dmatrix
             group_data = group_data.astype(str)
             formula = '0+' + '*'.join(listify(by))
             dm = dmatrix(formula, data=group_data, return_type='dataframe')

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -6,7 +6,6 @@ from .validation import BIDSValidator
 from grabbit import Layout, File
 from grabbit.external import six, inflect
 from grabbit.utils import listify
-import nibabel as nb
 from collections import defaultdict
 from functools import reduce, partial
 from itertools import chain
@@ -55,6 +54,7 @@ class BIDSFile(File):
     def image(self):
         """ Return the associated image file (if it exists) as a NiBabel object.
         """
+        import nibabel as nb
         try:
             return nb.load(self.path)
         except Exception as e:

--- a/bids/layout/validation.py
+++ b/bids/layout/validation.py
@@ -3,7 +3,6 @@
 import re
 import json
 from os.path import join, abspath, dirname
-import pandas as pd
 
 __all__ = ['BIDSValidator']
 
@@ -247,7 +246,8 @@ def check_duplicate_files(layout):
     identifier and the second column is the path to the file.
     Files with matching identifiers have the same content.
     """
-    
+    import pandas as pd
+
     def md5(fname):
         hash_md5 = hashlib.md5()
         with open(fname, "rb") as f:
@@ -305,6 +305,7 @@ def check_expected_files(layout, config):
     The more specific keys are provided, the more informative the output will be.
 
     """
+    import pandas as pd
 
     dictlist = []
     with open(config) as f:

--- a/bids/reports/parsing.py
+++ b/bids/reports/parsing.py
@@ -9,7 +9,6 @@ import logging
 from os.path import basename
 
 import numpy as np
-import nibabel as nib
 from num2words import num2words
 
 from .. import __version__
@@ -421,6 +420,7 @@ def parse_niftis(layout, niftis, subj, config, **kwargs):
     config : :obj:`dict`
         Configuration info for methods generation.
     """
+    import nibabel as nb
     kwargs = {k: v for k, v in kwargs.items() if v is not None}
 
     description_list = []
@@ -431,7 +431,7 @@ def parse_niftis(layout, niftis, subj, config, **kwargs):
         if not metadata:
             LOGGER.warning('No json file found for %s', nii_file)
         else:
-            img = nib.load(nii_file)
+            img = nb.load(nii_file)
 
             # Assume all data were acquired the same way.
             if not description_list:

--- a/bids/variables/entities.py
+++ b/bids/variables/entities.py
@@ -1,7 +1,6 @@
 from itertools import chain
 from collections import namedtuple
 from . import kollekshuns as clc
-import pandas as pd
 
 
 class Node(object):
@@ -59,6 +58,7 @@ class NodeIndex(Node):
     ''' Represents the top level in a BIDS hierarchy. '''
 
     def __init__(self):
+        import pandas as pd
         self.index = pd.DataFrame()
         self.nodes = []
 
@@ -173,6 +173,7 @@ class NodeIndex(Node):
             A Node instance.
 
         '''
+        import pandas as pd
 
         result = self.get_nodes(level, entities)
 

--- a/bids/variables/io.py
+++ b/bids/variables/io.py
@@ -1,5 +1,4 @@
 import numpy as np
-import nibabel as nb
 from os.path import join
 from bids.utils import listify
 from .entities import NodeIndex
@@ -115,6 +114,7 @@ def _load_time_variables(layout, dataset=None, columns=None, scan_length=None,
 
     Returns: A NodeIndex instance.
     '''
+    import nibabel as nb
     import pandas as pd
 
     # Extract any non-keyword arguments

--- a/bids/variables/io.py
+++ b/bids/variables/io.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pandas as pd
 import nibabel as nb
 from os.path import join
 from bids.utils import listify
@@ -116,6 +115,7 @@ def _load_time_variables(layout, dataset=None, columns=None, scan_length=None,
 
     Returns: A NodeIndex instance.
     '''
+    import pandas as pd
 
     # Extract any non-keyword arguments
     kwargs = selectors.copy()
@@ -305,6 +305,7 @@ def _load_tsv_variables(layout, suffix, dataset=None, columns=None,
 
     Returns: A NodeIndex instance.
     '''
+    import pandas as pd
 
     # Sanitize the selectors: only keep entities at current level or above
     remap = {'scans': 'run', 'sessions': 'session', 'participants': 'subject'}

--- a/bids/variables/kollekshuns.py
+++ b/bids/variables/kollekshuns.py
@@ -5,9 +5,7 @@ module of the same name on Python 2. We could go with something sensible but
 verbose like 'variable_collections', but that would make far too much sense.
 '''
 
-import pandas as pd
 from copy import copy
-from pandas.api.types import is_numeric_dtype
 import warnings
 import re
 from .variables import (SparseRunVariable, SimpleVariable, DenseRunVariable,
@@ -103,6 +101,7 @@ class BIDSVariableCollection(object):
 
         Returns: A pandas DataFrame.
         '''
+        import pandas as pd
 
         if variables is None:
             variables = list(self.variables.keys())
@@ -141,6 +140,7 @@ class BIDSVariableCollection(object):
         Returns:
             A BIDSVariableCollection.
         '''
+        import pandas as pd
         variables = []
         for col in data.columns:
             _data = pd.DataFrame(data[col].values, columns=['amplitude'])
@@ -170,6 +170,7 @@ class BIDSVariableCollection(object):
             will be {'subject': '01'}; the runs will be excluded as they vary
             across the Collection contents.
         '''
+        import pandas as pd
         all_ents = pd.DataFrame.from_records(
             [v.entities for v in self.variables.values()])
         constant = all_ents.apply(lambda x: x.nunique() == 1)
@@ -267,6 +268,7 @@ class BIDSRunVariableCollection(BIDSVariableCollection):
             if variables is not None and name not in variables:
                 continue
             if isinstance(var, SparseRunVariable):
+                from pandas.api.types import is_numeric_dtype
                 if force_dense and is_numeric_dtype(var.values):
                     _variables[name] = var.to_dense(sampling_rate)
             else:

--- a/bids/variables/variables.py
+++ b/bids/variables/variables.py
@@ -2,7 +2,6 @@ import numpy as np
 import math
 from copy import deepcopy
 from abc import abstractmethod, ABCMeta
-from scipy.interpolate import interp1d
 from bids.utils import listify
 from itertools import chain
 from six import add_metaclass
@@ -427,6 +426,7 @@ class DenseRunVariable(BIDSVariable):
             valid values. Default is 'linear'.
         '''
         import pandas as pd
+        from scipy.interpolate import interp1d
         if not inplace:
             var = self.clone()
             var.resample(sampling_rate, True, kind)

--- a/bids/variables/variables.py
+++ b/bids/variables/variables.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pandas as pd
 import math
 from copy import deepcopy
 from abc import abstractmethod, ABCMeta
@@ -40,6 +39,7 @@ class BIDSVariable(object):
         '''
         result = deepcopy(self)
         if data is not None:
+            import pandas as pd
             if data.shape != self.values.shape:
                 raise ValueError("Replacement data has shape %s; must have "
                                  "same shape as existing data %s." %
@@ -175,6 +175,7 @@ class BIDSVariable(object):
                 the current column name.
             entities (bool): If True, adds extra columns for all entities.
         '''
+        import pandas as pd
         amp = 'amplitude' if condition else self.name
         data = pd.DataFrame({amp: self.values.values.ravel()})
 
@@ -263,6 +264,7 @@ class SimpleVariable(BIDSVariable):
 
     @classmethod
     def _merge(cls, variables, name, **kwargs):
+        import pandas as pd
         dfs = [v.to_df() for v in variables]
         data = pd.concat(dfs, axis=0, sort=True).reset_index(drop=True)
         data = data.rename(columns={name: 'amplitude'})
@@ -358,6 +360,7 @@ class DenseRunVariable(BIDSVariable):
     '''
 
     def __init__(self, name, values, run_info, source, sampling_rate):
+        import pandas as pd
 
         values = pd.DataFrame(values)
 
@@ -383,6 +386,7 @@ class DenseRunVariable(BIDSVariable):
         -------
         A list of DenseRunVariables, one per unique value in the grouper.
         '''
+        import pandas as pd
         values = grouper.values * self.values.values
         df = pd.DataFrame(values, columns=grouper.columns)
         return [DenseRunVariable('%s.%s' % (self.name, name), df[name].values,
@@ -392,6 +396,7 @@ class DenseRunVariable(BIDSVariable):
 
     def _build_entity_index(self, run_info, sampling_rate):
         ''' Build the entity index from run information. '''
+        import pandas as pd
 
         index = []
         sr = int(round(1000. / sampling_rate))
@@ -421,6 +426,7 @@ class DenseRunVariable(BIDSVariable):
             the kind of interpolation approach to use. See interp1d docs for
             valid values. Default is 'linear'.
         '''
+        import pandas as pd
         if not inplace:
             var = self.clone()
             var.resample(sampling_rate, True, kind)
@@ -471,6 +477,7 @@ class DenseRunVariable(BIDSVariable):
 
     @classmethod
     def _merge(cls, variables, name, sampling_rate=None, **kwargs):
+        import pandas as pd
 
         if not isinstance(sampling_rate, int):
             rates = set([v.sampling_rate for v in variables])


### PR DESCRIPTION
Pybids is a pretty expensive import. Profiling the iterative effect of importing its dependencies:

```
numpy: 136 modules; 74.24ms, 116.4MiB
nibabel: 271 modules; 374.36ms, 23.0MiB
scipy.interpolate: 102 modules; 83.27ms, 22.1MiB
scipy.stats: 128 modules; 162.61ms, 9.2MiB
pandas: 255 modules; 195.02ms, 32.9MiB
patsy: 23 modules; 6.73ms, 0.8MiB
duecredit: 13 modules; 5.02ms, 0.2MiB
grabbit: 9 modules; 4.53ms, 0.5MiB
bids: 20 modules; 5.96ms, 0.5MiB
Final: 957 modules; 911.73ms, 205.6MiB
```

We can fairly easily drop `nibabel`, `scipy` and `pandas` (requires dropping `patsy` to actually drop) to reduce the profile to:

```
numpy: 136 modules; 77.51ms, 116.4MiB
duecredit: 17 modules; 20.41ms, -0.0MiB
grabbit: 14 modules; 11.42ms, 0.5MiB
bids: 24 modules; 71.11ms, 0.8MiB
Final: 191 modules; 180.45ms, 117.7MiB
```

Removing `numpy` wouldn't be too much more work, but it might be significantly more irritating to developers to have to import at the function level instead of module level. I will note, however, that it only appears in the `bids.analysis` submodule, not in `bids.layout`. Given that most *users* only use `BIDSLayout`, and that's likely to remain true, it might be worth shaving it off, as well.