### PR TITLE
CI: Disable allowed failures for Python 2.7 nightly tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,6 @@ matrix:
       env:
         - PYTHON_VERSION=3.6
         - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
-  allow_failures:
-    - python: 2.7
-      env: EXTRA_PIP_FLAGS="--pre --find-links=$EXTRA_WHEELS --find-links $PRE_WHEELS"
 
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/bids/version.py
+++ b/bids/version.py
@@ -45,8 +45,7 @@ AUTHOR = "PyBIDS developers"
 AUTHOR_EMAIL = "bids-discussion@googlegroups.com"
 PLATFORMS = "OS Independent"
 # No data for now
-REQUIRES = ["grabbit==0.2.5", "six", "num2words", "numpy", "scipy",
-            'enum34; python_version < "3.4"', "pandas",
+REQUIRES = ["grabbit==0.2.5", "six", "num2words", "numpy", "scipy", "pandas",
             "nibabel>=2.1", "patsy"]
 EXTRAS_REQUIRE = {
    # Just to not break compatibility with externals requiring

--- a/bids/version.py
+++ b/bids/version.py
@@ -45,7 +45,8 @@ AUTHOR = "PyBIDS developers"
 AUTHOR_EMAIL = "bids-discussion@googlegroups.com"
 PLATFORMS = "OS Independent"
 # No data for now
-REQUIRES = ["grabbit==0.2.5", "six", "num2words", "numpy", "scipy", "pandas",
+REQUIRES = ["grabbit==0.2.5", "six", "num2words", "numpy", "scipy",
+            'enum34; python_version < "3.4"', "pandas",
             "nibabel>=2.1", "patsy"]
 EXTRAS_REQUIRE = {
    # Just to not break compatibility with externals requiring


### PR DESCRIPTION
This may be the root of the Pandas nightly failures.