### PR TITLE
Lowercase t-contrast

### DIFF
--- a/bids/analysis/analysis.py
+++ b/bids/analysis/analysis.py
@@ -451,7 +451,7 @@ class AnalysisNode(object):
                         'name': col_name,
                         'condition_list': [col_name],
                         'weights': [1],
-                        'type': 'T'
+                        'type': 't'
                     })
 
         # Filter on desired contrast names if passed
@@ -467,7 +467,7 @@ class AnalysisNode(object):
                 weights = pd.concat([weights, var_df],
                                     sort=True)[variables].fillna(0)
 
-            test_type = c.get('type', ('T' if len(weights) == 1 else 'F'))
+            test_type = c.get('type', ('t' if len(weights) == 1 else 'F'))
 
             return ContrastInfo(c['name'], weights, test_type, self.entities)
 

--- a/bids/analysis/auto_model.py
+++ b/bids/analysis/auto_model.py
@@ -10,7 +10,7 @@ def _make_passthrough_contrast(level, contrast_names):
     contrasts = []
     for cn in contrast_names:
         cdict = OrderedDict(Name=level.lower() + "_" + cn, ConditionList=[cn],
-                            Weights=[1], Type='T')
+                            Weights=[1], Type='t')
         contrasts.append(cdict)
     block["Contrasts"] = contrasts
     return block
@@ -88,7 +88,7 @@ def auto_model(layout, scan_length=None, one_vs_rest=False):
                     pass
                 cdict["Weights"] = list(weights)
 
-                cdict["Type"] = "T"
+                cdict["Type"] = "t"
                 contrasts.append(cdict)
 
             run["Contrasts"] = contrasts

--- a/bids/analysis/tests/test_analysis.py
+++ b/bids/analysis/tests/test_analysis.py
@@ -115,9 +115,9 @@ def test_contrast_info(analysis):
     assert len(contrast_lists) == 3
     for cl in contrast_lists:
         assert len(cl) == 3
-        cl = [c for c in cl if c.type == 'T']
+        cl = [c for c in cl if c.type == 't']
         assert set([c.name for c in cl]) == {'RT', 'RT-trial_type'}
-        assert set([c.type for c in cl]) == {'T'}
+        assert set([c.type for c in cl]) == {'t'}
         assert cl[0].weights.columns.tolist() == ['RT', 'trial_type']
         assert cl[1].weights.columns.tolist() == ['RT']
         assert np.array_equal(cl[0].weights.values, np.array([[1, -1]]))
@@ -133,9 +133,9 @@ def test_contrast_info_with_specified_variables(analysis):
     assert len(contrast_lists) == 3
     for cl in contrast_lists:
         assert len(cl) == 3
-        cl = [c for c in cl if c.type == 'T']
+        cl = [c for c in cl if c.type == 't']
         assert set([c.name for c in cl]) == {'RT', 'RT-trial_type'}
-        assert set([c.type for c in cl]) == {'T'}
+        assert set([c.type for c in cl]) == {'t'}
         for c in cl:
             assert c.weights.columns.tolist() == ['RT', 'dummy']
             assert np.array_equal(c.weights.values, np.array([[1, 0]]))


### PR DESCRIPTION
Contrast type: 't' was incorrectly capitalized, which is not in accordance with the BIDS StatsModels spec.

This PR fixes that
