### PR TITLE
remove heavy imports from top level

### DIFF
--- a/bids/__init__.py
+++ b/bids/__init__.py
@@ -1,19 +1,18 @@
 from __future__ import absolute_import, division, print_function
 from .due import due, Doi
-
-from .analysis import Analysis
 from .layout import BIDSLayout, BIDSValidator
-from .variables.io import load_variables
 
 
 __all__ = [
     "analysis",
-    "layout",
-    "reports",
     "BIDSLayout",
     "BIDSValidator",
-    "Analysis",
-    "load_variables"
+    "config",
+    "layout",
+    "reports",
+    "utils",
+    "variables"
+
 ]
 
 due.cite(Doi("10.1038/sdata.2016.44"),

--- a/bids/layout/__init__.py
+++ b/bids/layout/__init__.py
@@ -1,3 +1,4 @@
 from .layout import BIDSLayout, add_config_paths
 from .validation import BIDSValidator
+
 __all__ = ["BIDSLayout", "BIDSValidator", "add_config_paths"]

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -8,11 +8,11 @@ from .. import config as cf
 from grabbit import Layout, File
 from grabbit.external import six, inflect
 from grabbit.utils import listify
-import nibabel as nb
 from collections import defaultdict
 from functools import reduce, partial
 from itertools import chain
 from bids.config import get_option
+
 
 try:
     from os.path import commonpath
@@ -76,6 +76,7 @@ class BIDSFile(File):
         """ Return the associated image file (if it exists) as a NiBabel object.
         """
         try:
+            import nibabel as nb
             return nb.load(self.path)
         except Exception:
             return None

--- a/bids/layout/validation.py
+++ b/bids/layout/validation.py
@@ -3,7 +3,7 @@
 import re
 import json
 from os.path import join, abspath, dirname
-import pandas as pd
+
 
 __all__ = ['BIDSValidator']
 
@@ -248,6 +248,7 @@ def check_duplicate_files(layout):
     Files with matching identifiers have the same content.
     """
     
+    import pandas as pd
     def md5(fname):
         hash_md5 = hashlib.md5()
         with open(fname, "rb") as f:
@@ -306,6 +307,7 @@ def check_expected_files(layout, config):
 
     """
 
+    import pandas as pd
     dictlist = []
     with open(config) as f:
         json_data = json.load(f)

--- a/bids/reports/parsing.py
+++ b/bids/reports/parsing.py
@@ -8,8 +8,7 @@ from __future__ import print_function
 import logging
 from os.path import basename
 
-import numpy as np
-import nibabel as nib
+import math
 from num2words import num2words
 
 from .. import __version__
@@ -104,7 +103,7 @@ def func_info(task, n_runs, metadata, img, config):
 
     tr = metadata['RepetitionTime']
     n_tps = img.shape[3]
-    run_secs = np.ceil(n_tps * tr)
+    run_secs = math.ceil(n_tps * tr)
     mins, secs = divmod(run_secs, 60)
     length = '{0}:{1:02.0f}'.format(int(mins), int(secs))
 
@@ -431,6 +430,7 @@ def parse_niftis(layout, niftis, subj, config, **kwargs):
         if not metadata:
             LOGGER.warning('No json file found for %s', nii_file)
         else:
+            import nibabel as nib
             img = nib.load(nii_file)
 
             # Assume all data were acquired the same way.

--- a/bids/reports/utils.py
+++ b/bids/reports/utils.py
@@ -5,9 +5,6 @@ methods section from a BIDS dataset.
 """
 from __future__ import print_function
 import logging
-
-import numpy as np
-
 from .. import __version__
 
 logging.basicConfig()
@@ -160,6 +157,7 @@ def get_sizestr(img):
         Field of view string (e.g., '256x256')
     """
     n_x, n_y, n_slices = img.shape[:3]
+    import numpy as np
     voxel_dims = np.array(img.header.get_zooms()[:3])
     matrix_size = '{0}x{1}'.format(num_to_str(n_x), num_to_str(n_y))
     voxel_size = 'x'.join([num_to_str(s) for s in voxel_dims])

--- a/bids/variables/io.py
+++ b/bids/variables/io.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pandas as pd
-import nibabel as nb
 from os.path import join
 from bids.utils import listify
 from .entities import NodeIndex
@@ -146,6 +145,7 @@ def _load_time_variables(layout, dataset=None, columns=None, scan_length=None,
         # header; if that fails, try to get NumberOfVolumes from the
         # run metadata; if that fails, look for a scan_length argument.
         try:
+            import nibabel as nb
             img = nb.load(img_f)
             duration = img.shape[3] * img.header.get_zooms()[-1]
         except Exception as e:


### PR DESCRIPTION
This PR ensures that importing from the `bids` or `bids.layout` namespaces won't automatically import heavy dependencies like pandas, numpy, and nibabel.

For discussion, see #314. The present changes represent a hybrid between the approaches suggested in that thread. Most of the work is done by removing imports like `analysis.Analysis` and `variables.io.load_variables` from the top-level `__init__.py`, but in cases where the imported libraries are well-isolated, I've followed @effigies and moved the import statement inside the relevant code block.

Effects on existing workflows should be minimal and easy to fix.