### PR TITLE
FIX: Do not update model input selectors in-place

### DIFF
--- a/bids/analysis/analysis.py
+++ b/bids/analysis/analysis.py
@@ -82,7 +82,7 @@ class Analysis(object):
         input_nodes = None
 
         # Use inputs from model, and update with kwargs
-        selectors = self.model.get('input', {})
+        selectors = self.model.get('input', {}).copy()
         selectors.update(kwargs)
 
         for i, b in enumerate(self.steps):


### PR DESCRIPTION
```Python
analysis = Analysis(layout=layout, model=model_file)
selectors = analysis.model.get('input', {})
pprint(selectors)
analysis.setup(desc='preproc', subject=participants, drop_na=True)
selectors = analysis.model.get('input', {})
pprint(selectors)
```

Yields
```Python
{'task': 'facerecognition'}
{'task': 'facerecognition',
 'desc': 'preproc',
 'subject': ['01', '02', '03'],
 'drop_na': True}
```

I assume the intended behavior is a temporary dictionary containing all of these keyword arguments, rather than updating the `input` dictionary in-place.