### PR TITLE
Adds target hints

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -398,7 +398,7 @@ class BIDSLayout(Layout):
                 md_kwargs[k] = v
 
         # Provide some suggestions if target is specified and invalid.
-        if target is not None and target not in ent_kwargs:
+        if target is not None and target not in all_ents:
             import difflib
             potential = list(all_ents.keys())
             suggestions = difflib.get_close_matches(target, potential)

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -397,6 +397,18 @@ class BIDSLayout(Layout):
             else:
                 md_kwargs[k] = v
 
+        # Provide some suggestions if target is specified and invalid.
+        if target is not None and target not in ent_kwargs:
+            import difflib
+            potential = list(all_ents.keys())
+            suggestions = difflib.get_close_matches(target, potential)
+            if suggestions:
+                message = "Did you mean one of: {}?".format(suggestions)
+            else:
+                message = "Valid targets are: {}".format(potential)
+            raise ValueError(("Unknown target '{}'. " + message)
+                             .format(target))
+
         all_results = []
 
         # Get entity-based search results using the superclass's get()

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -135,6 +135,17 @@ def test_get_metadata_via_bidsfile(layout_7t_trt):
     assert 'subject' not in result
 
 
+def test_get_with_bad_target(layout_7t_trt):
+    with pytest.raises(ValueError) as exc:
+        layout_7t_trt.get(target='unicorn')
+        msg = exc.value.message
+        assert 'subject' in msg and 'reconstruction' in msg and 'proc' in msg
+    with pytest.raises(ValueError) as exc:
+        layout_7t_trt.get(target='sub')
+        msg = exc.value.message
+        assert 'subject' in msg and 'reconstruction' not in msg
+
+
 def test_get_bvals_bvecs(layout_ds005):
     dwifile = layout_ds005.get(subject="01", datatype="dwi")[0]
     result = layout_ds005.get_bval(dwifile.path)


### PR DESCRIPTION
When a bad `target` argument is passed to `get`, suggests viable candidates instead of failing silently. Closes #266.