### PR TITLE
Updates link to derivative config file in notebook

### DIFF
--- a/examples/pybids tutorial.ipynb
+++ b/examples/pybids tutorial.ipynb
@@ -482,7 +482,7 @@
    "source": [
     "### Loading derivatives\n",
     "\n",
-    "By default, `BIDSLayout` objects are initialized without scanning contained `derivatives/` directories. But you can easily ensure that all derivatives files are loaded and endowed with the extra structure specified in the [derivatives config file](https://github.com/bids-standard/pybids/blob/master/bids/grabbids/config/derivatives.json):"
+    "By default, `BIDSLayout` objects are initialized without scanning contained `derivatives/` directories. But you can easily ensure that all derivatives files are loaded and endowed with the extra structure specified in the [derivatives config file](https://github.com/bids-standard/pybids/blob/master/bids/layout/config/derivatives.json):"
    ]
   },
   {


### PR DESCRIPTION
The link to the "derivatives config file" in the example notebook seems to be broken since v0.7.0.

It currently links to https://github.com/bids-standard/pybids/blob/master/bids/grabbids/config/derivatives.json, which doesn't exist anymore.

I updated the link to https://github.com/bids-standard/pybids/blob/master/bids/layout/config/derivatives.json, as I assume that it should link to this config file.