### PR TITLE
Demand pandas >= 0.23.0

### DIFF
--- a/bids/version.py
+++ b/bids/version.py
@@ -45,7 +45,7 @@ AUTHOR = "PyBIDS developers"
 AUTHOR_EMAIL = "bids-discussion@googlegroups.com"
 PLATFORMS = "OS Independent"
 # No data for now
-REQUIRES = ["grabbit==0.2.6", "six", "num2words", "numpy", "scipy", "pandas",
+REQUIRES = ["grabbit==0.2.6", "six", "num2words", "numpy", "scipy", "pandas>=0.23.0",
             "nibabel>=2.1", "patsy"]
 EXTRAS_REQUIRE = {
    # Just to not break compatibility with externals requiring


### PR DESCRIPTION
got following crash
```
  File "/home/adina/Repos/pybids/bids/variables/io.py", line 229, in _load_time_variables
    'regressors', sr)
  File "/home/adina/Repos/pybids/bids/variables/variables.py", line 380, in __init__
    self.index = self._build_entity_index(run_info, sampling_rate)
  File "/home/adina/Repos/pybids/bids/variables/variables.py", line 418, in _build_entity_index
    self.timestamps = pd.concat(_timestamps, axis=0, sort=True)
TypeError: concat() got an unexpected keyword argument 'sort'

```
and according to the https://pandas.pydata.org/pandas-docs/version/0.23.4/generated/pandas.concat.html  sort parameter was introduced in pandas 0.23.0

@yarikoptic says Hi