### PR TITLE
If sampling_rate is auto, set to first rate of DenseRunVariables

### DIFF
--- a/bids/variables/kollekshuns.py
+++ b/bids/variables/kollekshuns.py
@@ -228,6 +228,9 @@ class BIDSRunVariableCollection(BIDSVariableCollection):
     def __init__(self, variables, sampling_rate=None):
         # Don't put the default value in signature because None is passed from
         # several places and we don't want multiple conflicting defaults.
+        if sampling_rate:
+            if isinstance(sampling_rate, str):
+                raise ValueError("Sampling rate must be numeric.")
         self.sampling_rate = sampling_rate or 10
         super(BIDSRunVariableCollection, self).__init__(variables)
 
@@ -376,6 +379,12 @@ def merge_collections(collections, force_dense=False, sampling_rate='auto'):
     variables = cls.merge_variables(variables, sampling_rate=sampling_rate)
 
     if isinstance(collections[0], BIDSRunVariableCollection):
+        if sampling_rate == 'auto':
+            rates = [var.sampling_rate for var in variables
+                     if isinstance(var, DenseRunVariable)]
+
+            sampling_rate = rates[0] if rates else None
+
         return cls(variables, sampling_rate)
 
     return cls(variables)


### PR DESCRIPTION
Fix #349 
sampling_rate = 'auto' should be confined to `merge_collections` and not passed onward to `BIDSRunVariableCollection`

- Added fix for setting sampling_rate to that set by `merge_variables`
- Added check for non-string sampling_rate

@Shotgunosine does this fix your issue

Still need to add a test. Turns out there were no tests of merging Dense variables