### PR TITLE
ENH/BF: add check for run_info to be a list, pass run_info in correct position.

### DIFF
--- a/bids/variables/__init__.py
+++ b/bids/variables/__init__.py
@@ -9,7 +9,6 @@ __all__ = [
     'SimpleVariable',
     'SparseRunVariable',
     'DenseRunVariable',
-    'BIDSRunInfo',
     'BIDSVariableCollection',
     'BIDSRunVariableCollection',
     'merge_collections',

--- a/bids/variables/variables.py
+++ b/bids/variables/variables.py
@@ -253,9 +253,7 @@ class SimpleVariable(BIDSVariable):
         subsets = []
         for i, (name, g) in enumerate(data.groupby(grouper)):
             name = '%s.%s' % (self.name, name)
-            args = [name, g, self.source]
-            if hasattr(self, 'run_info'):
-                args.append(self.run_info)
+            args = [name, g, getattr(self, 'run_info', None), self.source]
             col = self.__class__(*args)
             subsets.append(col)
         return subsets

--- a/bids/variables/variables.py
+++ b/bids/variables/variables.py
@@ -301,6 +301,9 @@ class SparseRunVariable(SimpleVariable):
     def __init__(self, name, data, run_info, source, **kwargs):
         if hasattr(run_info, 'duration'):
             run_info = [run_info]
+        if not isinstance(run_info, list):
+            raise TypeError("We expect a list of run_info, got %s"
+                            % repr(run_info))
         self.run_info = run_info
         for sc in self._property_columns:
             setattr(self, sc, data.pop(sc).values)


### PR DESCRIPTION
Previously, a Split transformation failed, ref: https://github.com/bids-standard/pybids/issues/352.

This PR should hopefully fix this.

Also, @yarikoptic annihilated BIDSRunInfo which is not present anymore.