### PR TITLE
BUG: Resampled column has one too many rows

### DIFF
--- a/bids/variables/variables.py
+++ b/bids/variables/variables.py
@@ -323,7 +323,7 @@ class SparseRunVariable(SimpleVariable):
             A DenseRunVariable.
 
         '''
-        duration = int(math.ceil(sampling_rate * self.get_duration()))
+        duration = int(np.round(sampling_rate * self.get_duration()))
         ts = np.zeros(duration, dtype=self.values.dtype)
 
         onsets = np.round(self.onset * sampling_rate).astype(int)


### PR DESCRIPTION
Here's a test to demonstrate what I described in #355. There's probably a way to do this without a simulated layout, but hopefully this demonstrates the issue in a plausible context.

I don't understand the cause yet. @tyarkoni Please let me know if it's obvious to you.