### PR TITLE
ENH: issue warning when silently incrementing runs

### DIFF
--- a/bids/variables/variables.py
+++ b/bids/variables/variables.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 import math
+import warnings
 from copy import deepcopy
 from abc import abstractmethod, ABCMeta
 from bids.utils import listify
@@ -336,6 +337,9 @@ class SparseRunVariable(SimpleVariable):
                 run_i += 1
             _onset = int(start + onsets[i])
             _offset = int(_onset + durations[i])
+            if _onset >= duration:
+                warnings.warn("The onset time of a variable seems to exceed the runs"
+                              "duration, hence runs are incremented by one internally.")
             ts[_onset:_offset] = val
             last_ind = onsets[i]
 


### PR DESCRIPTION
@yarikoptic and I were thinking about what is happening here. It seems to us as if `onset` is assumed to be non-decreasing within a run, and non-increasing across/at the change of runs, because whenever a subsequent onset time is smaller than the previous one, the event seems to be assigned to the next run (or rather: the run count `run_i` gets increased). If is is the case that runs are incremented based on onset, would that not be incorrect logic as it would imply that...

- I can't have an events.tsv file with unsorted onsets, for example when appending interleaved events and their duration event-wise 
as in 
Event      | Onset
----------- | --------
Event_A  | 1.0
Event_A  | 5.0
Event_B  | 2.0
Event_B  | 6.0
[...]
(or have we overlooked `onsets` being sorted earlier?, or thinking wrong in a different way?)

- I can't have consecutive runs 1 and 2 where the last Event_A of run 1 occurs earlier than the first Event_B of run 2 (because run_i would not get incremented in this case).

and
- that If a variable is not present in a specific run that is not the last run, it would get accidentally assigned to the wrong run

These might all just be wrong inferences, but if we think correctly, this would silently change the design the user is giving with the event files, so we thought at least a warning would be appropriate. Ideally though, every event should unambiguously be associated with its run.
Maybe a check for monotonic increase withing the onsets of each run is also useful as eg
`assert onsets[1:] >= onsets[:-1]` and sorting, if failing?