### PR TITLE
BF(PY2): retain compatibility with Python 2 by using io.open

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -14,6 +14,9 @@ from .core import Config, BIDSFile, BIDSRootNode
 from .validation import BIDSValidator
 from .. import config as cf
 
+if six.PY2:
+    # To be able to pass encoding kwarg
+    from io import open
 
 def add_config_paths(**kwargs):
     """ Add to the pool of available configuration files for BIDSLayout.


### PR DESCRIPTION
spotted while trying to run tests on datalad_neuroimaging.  So far that was the only problem although our tests do not look "too deep". Eventually will do more checks.

Cheers!