### PR TITLE
FIX: Pass new variable args as kwargs in split()

### DIFF
--- a/bids/analysis/tests/test_transformations.py
+++ b/bids/analysis/tests/test_transformations.py
@@ -29,7 +29,7 @@ def sparse_run_variable_with_missing_values():
         'amplitude': [1, 1, np.nan, 1]
     })
     run_info = [RunInfo({'subject': '01'}, 20, 2, 'dummy.nii.gz')]
-    var = SparseRunVariable('var', data, run_info, 'events')
+    var = SparseRunVariable(name='var', data=data, run_info=run_info, source='events')
     return BIDSRunVariableCollection([var])
 
 

--- a/bids/analysis/transformations/compute.py
+++ b/bids/analysis/transformations/compute.py
@@ -52,9 +52,8 @@ class Convolve(Transformation):
         convolved = hrf.compute_regressor(vals, model, onsets,
                                           fir_delays=fir_delays, min_onset=0)
 
-        return DenseRunVariable(var.name, convolved[0],
-            var.run_info, var.source,
-            var.sampling_rate)
+        return DenseRunVariable(name=var.name, values=convolved[0], run_info=var.run_info,
+                                source=var.source, sampling_rate=var.sampling_rate)
 
 
 class Demean(Transformation):

--- a/bids/variables/io.py
+++ b/bids/variables/io.py
@@ -210,7 +210,8 @@ def _load_time_variables(layout, dataset=None, columns=None, scan_length=None,
                         if df.empty:
                             continue
 
-                        var = SparseRunVariable(col, df, run_info, 'events')
+                        var = SparseRunVariable(name=col, data=df, run_info=run_info,
+                                                source='events')
                         run.add_variable(var)
 
         # Process confound files
@@ -225,8 +226,9 @@ def _load_time_variables(layout, dataset=None, columns=None, scan_length=None,
                     _data = _data.loc[:, conf_cols]
                 for col in _data.columns:
                     sr = 1. / run.repetition_time
-                    var = DenseRunVariable(col, _data[[col]], run_info,
-                                           'regressors', sr)
+                    var = DenseRunVariable(name=col, values=_data[[col]],
+                                           run_info=run_info, source='regressors',
+                                           sampling_rate=sr)
                     run.add_variable(var)
 
         # Process recordinging files
@@ -279,8 +281,8 @@ def _load_time_variables(layout, dataset=None, columns=None, scan_length=None,
                 df = pd.DataFrame(values, columns=rf_cols)
                 source = 'physio' if '_physio.tsv' in rf else 'stim'
                 for col in df.columns:
-                    var = DenseRunVariable(col, df[[col]], run_info, source,
-                                           freq)
+                    var = DenseRunVariable(name=col, values=df[[col]], run_info=run_info,
+                                           source=source, sampling_rate=freq)
                     run.add_variable(var)
     return dataset
 
@@ -400,6 +402,6 @@ def _load_tsv_variables(layout, suffix, dataset=None, columns=None,
             if prepend_type:
                 col_name = '%s.%s' % (suffix, col_name)
 
-            node.add_variable(SimpleVariable(col_name, df, suffix))
+            node.add_variable(SimpleVariable(name=col_name, data=df, source=suffix))
 
     return dataset

--- a/bids/variables/kollekshuns.py
+++ b/bids/variables/kollekshuns.py
@@ -146,7 +146,7 @@ class BIDSVariableCollection(object):
             _data = pd.DataFrame(data[col].values, columns=['amplitude'])
             if entities is not None:
                 _data = pd.concat([_data, entities], axis=1, sort=True)
-            variables.append(SimpleVariable(col, _data, source))
+            variables.append(SimpleVariable(name=col, data=_data, source=source))
         return BIDSVariableCollection(variables)
 
     def clone(self):

--- a/bids/variables/tests/test_variables.py
+++ b/bids/variables/tests/test_variables.py
@@ -20,7 +20,8 @@ def generate_DEV(name='test', sr=20, duration=480):
     entities = {e: uuid.uuid4().hex for e in ent_names}
     image = uuid.uuid4().hex + '.nii.gz'
     run_info = RunInfo(entities, duration, 2, image)
-    return DenseRunVariable('test', values, run_info, 'dummy', sr)
+    return DenseRunVariable(name='test', values=values, run_info=run_info,
+                            source='dummy', sampling_rate=sr)
 
 
 @pytest.fixture

--- a/bids/variables/variables.py
+++ b/bids/variables/variables.py
@@ -340,8 +340,12 @@ class SparseRunVariable(SimpleVariable):
             last_ind = onsets[i]
 
         run_info = list(self.run_info)
-        return DenseRunVariable(self.name, ts, run_info, self.source,
-                                sampling_rate)
+        return DenseRunVariable(
+            name=self.name,
+            values=ts,
+            run_info=run_info,
+            source=self.source,
+            sampling_rate=sampling_rate)
 
     @classmethod
     def _merge(cls, variables, name, **kwargs):
@@ -398,9 +402,11 @@ class DenseRunVariable(BIDSVariable):
         '''
         values = grouper.values * self.values.values
         df = pd.DataFrame(values, columns=grouper.columns)
-        return [DenseRunVariable('%s.%s' % (self.name, name), df[name].values,
-                                 self.run_info, self.source,
-                                 self.sampling_rate)
+        return [DenseRunVariable(name='%s.%s' % (self.name, name),
+                                 values=df[name].values,
+                                 run_info=self.run_info,
+                                 source=self.source,
+                                 sampling_rate=self.sampling_rate)
                 for i, name in enumerate(df.columns)]
 
     def _build_entity_index(self, run_info, sampling_rate):
@@ -506,7 +512,12 @@ class DenseRunVariable(BIDSVariable):
         values = pd.concat([v.values for v in variables], axis=0, sort=True)
         run_info = list(chain(*[v.run_info for v in variables]))
         source = variables[0].source
-        return DenseRunVariable(name, values, run_info, source, sampling_rate)
+        return DenseRunVariable(
+            name=name,
+            values=values,
+            run_info=run_info,
+            source=source,
+            sampling_rate=sampling_rate)
 
 
 def merge_variables(variables, name=None, **kwargs):

--- a/bids/variables/variables.py
+++ b/bids/variables/variables.py
@@ -253,8 +253,8 @@ class SimpleVariable(BIDSVariable):
         subsets = []
         for i, (name, g) in enumerate(data.groupby(grouper)):
             name = '%s.%s' % (self.name, name)
-            args = [name, g, getattr(self, 'run_info', None), self.source]
-            col = self.__class__(*args)
+            col = self.__class__(name=name, data=g, source=self.source,
+                                 run_info=getattr(self, 'run_info', None))
             subsets.append(col)
         return subsets
 


### PR DESCRIPTION
`SimpleVariable.__init__` does not take a `run_info` parameter, while `SparseRunVariable.__init__` does. Further, the order of the other variables is inconsistent, so subclassing works poorly. The fix in #353 used positional arguments, which worked for `SparseRunVariable`, but failed for `SimpleVariable`. This fix uses kwargs to avoid the ordering problem. Because `SparseRunVariable.__init__` accepts a `**kwargs` parameter and does nothing with it, this is safe.

Related to #352/#353. I think there was another issue where I ran into this, but I can't find it right now.

Cherry-picked from #376.