### PR TITLE
ENH: .get() - natural_sort BIDSFile entries as well for consistency

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -559,6 +559,8 @@ class BIDSLayout(object):
             else:
                 raise ValueError("Invalid return_type specified (must be one "
                                  "of 'tuple', 'file', 'id', or 'dir'.")
+        else:
+            results = natural_sort(results, 'path')
 
         return results
 

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -232,10 +232,12 @@ def test_bids_json(layout_7t_trt):
 def test_get_return_type_dir(layout_7t_trt):
     l = layout_7t_trt
     res = l.get(target='subject', return_type='dir')
-    for i in range(1, 11):
-        sub_dir = "sub-{:02d}".format(i)
-        assert os.path.join(get_test_data_path(), '7t_trt', sub_dir) in res
-    assert len(res) == 10
+    # returned directories should be in sorted order so we can match exactly
+    target = [
+        os.path.join(get_test_data_path(), '7t_trt', "sub-{:02d}".format(i))
+        for i in range(1, 11)
+    ]
+    assert target == res
 
 
 def test_force_index(layout_ds005, layout_ds005_models):

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -8,6 +8,7 @@ from bids.layout import BIDSLayout, parse_file_entities, add_config_paths
 from bids.layout.core import BIDSFile, Entity, Config
 from os.path import join, abspath, basename, dirname
 from bids.tests import get_test_data_path
+from bids.utils import natural_sort
 
 
 # Fixture uses in the rest of the tests
@@ -238,6 +239,15 @@ def test_get_return_type_dir(layout_7t_trt):
         for i in range(1, 11)
     ]
     assert target == res
+
+
+def test_get_return_sorted(layout_7t_trt):
+    bids_files = layout_7t_trt.get(target='subject')
+    paths = [r.path for r in bids_files]
+    assert natural_sort(paths) == paths
+
+    files = layout_7t_trt.get(target='subject', return_type='file')
+    assert files == paths
 
 
 def test_force_index(layout_ds005, layout_ds005_models):


### PR DESCRIPTION
- also made the test on "dirs" return type verify that return value is sorted

will be useful as preventative measure for demos/tutorials to not change their output randomly