### PR TITLE
Update layout docstring to mention old behavior

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -465,6 +465,13 @@ class BIDSLayout(object):
 
         Returns:
             A list of BIDSFiles (default) or strings (see return_type).
+
+        Notes:
+            As of pybids 0.7.0 some keywords have been changed. Namely: 'type'
+            becomes 'suffix', 'modality' becomes 'datatype', 'acq' is removed
+            and 'mod' becomes 'modality'. Using the wrong version could result
+            in the get() silently returning wrong or no results. See the
+            changelog for more details.
         """
 
         # Warn users still expecting 0.6 behavior

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -280,7 +280,7 @@ class BIDSLayout(object):
                 or deriv.description["PipelineDescription"]['Name'] in scope):
                 layouts.append(deriv)
         return layouts
-    
+
     def __getattr__(self, key):
         ''' Dynamically inspect missing methods for get_<entity>() calls
         and return a partial function of get() if a match is found. '''

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -468,10 +468,10 @@ class BIDSLayout(object):
 
         Notes:
             As of pybids 0.7.0 some keywords have been changed. Namely: 'type'
-            becomes 'suffix', 'modality' becomes 'datatype', 'acq' is removed
-            and 'mod' becomes 'modality'. Using the wrong version could result
-            in get() silently returning wrong or no results. See the changelog
-            for more details.
+            becomes 'suffix', 'modality' becomes 'datatype', 'acq' becomes 
+            'acquisition' and 'mod' becomes 'modality'. Using the wrong version 
+            could result in get() silently returning wrong or no results. See 
+            the changelog for more details.
         """
 
         # Warn users still expecting 0.6 behavior

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -470,8 +470,8 @@ class BIDSLayout(object):
             As of pybids 0.7.0 some keywords have been changed. Namely: 'type'
             becomes 'suffix', 'modality' becomes 'datatype', 'acq' is removed
             and 'mod' becomes 'modality'. Using the wrong version could result
-            in the get() silently returning wrong or no results. See the
-            changelog for more details.
+            in get() silently returning wrong or no results. See the changelog
+            for more details.
         """
 
         # Warn users still expecting 0.6 behavior

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -280,7 +280,7 @@ class BIDSLayout(object):
                 or deriv.description["PipelineDescription"]['Name'] in scope):
                 layouts.append(deriv)
         return layouts
-
+    
     def __getattr__(self, key):
         ''' Dynamically inspect missing methods for get_<entity>() calls
         and return a partial function of get() if a match is found. '''


### PR DESCRIPTION
Closes #384 

This is a suggestion for a note in the docstring and documentation for layout.py in order to inform about some API-changes from 0.6.0 to 0.7.0.

I have tried to follow the style from other notes, but could very well have messed something up.