### PR TITLE
ENH: Improve convolution performance for Sparse variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ before_install:
     - source venv/bin/activate
     - python --version # just to check
     - travis_retry pip install -U pip setuptools wheel  # needed at one point
-    - travis_retry pip install pytest pytest-xdist pytest-cov codecov
+    - travis_retry pip install pytest pytest-xdist pytest-cov codecov mock
     - travis_retry pip install pathlib
 
 install:

--- a/bids/analysis/tests/test_transformations.py
+++ b/bids/analysis/tests/test_transformations.py
@@ -5,12 +5,15 @@ from bids.variables.entities import RunInfo
 from bids.variables.kollekshuns import BIDSRunVariableCollection
 from bids.layout import BIDSLayout
 import pytest
-from unittest import mock
 from os.path import join, sep
 from bids.tests import get_test_data_path
 import numpy as np
 import pandas as pd
 
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 @pytest.fixture
 def collection():

--- a/bids/analysis/tests/test_transformations.py
+++ b/bids/analysis/tests/test_transformations.py
@@ -15,6 +15,7 @@ try:
 except ImportError:
     import mock
 
+
 @pytest.fixture
 def collection():
     layout_path = join(get_test_data_path(), 'ds005')
@@ -65,14 +66,14 @@ def test_convolve(collection):
         transform.Convolve(collection, 'rt_dense', output='rt_mock')
         mocked.compute_regressor.assert_called_with(
             mock.ANY, 'spm', mock.ANY, fir_delays=None, min_onset=0,
-            oversampling=2.0)
+            oversampling=3.0)
 
     with mock.patch('bids.analysis.transformations.compute.hrf') as mocked:
-        collection.sampling_rate = 0.1
+        collection.sampling_rate = 0.5
         transform.Convolve(collection, 'RT', output='rt_mock')
         mocked.compute_regressor.assert_called_with(
             mock.ANY, 'spm', mock.ANY, fir_delays=None, min_onset=0,
-            oversampling=5.0)
+            oversampling=2.0)
 
 
 def test_rename(collection):

--- a/bids/analysis/transformations/compute.py
+++ b/bids/analysis/transformations/compute.py
@@ -1,7 +1,7 @@
 '''
 Transformations that primarily involve numerical computation on variables.
 '''
-
+from __future__ import division
 import numpy as np
 import pandas as pd
 from bids.utils import listify
@@ -56,7 +56,8 @@ class Convolve(Transformation):
             raise ValueError("Model must be one of 'spm', 'glover', or 'fir'.")
 
         oversampling = np.ceil(
-            1 / np.ediff1d(var.onset).min() * (1/sampling_rate))
+            1 / min([np.ediff1d(var.onset).min(), var.duration.min()])
+            * (1/sampling_rate))
 
         convolved = hrf.compute_regressor(
             vals, model, resample_frames, fir_delays=fir_delays, min_onset=0,

--- a/bids/analysis/transformations/compute.py
+++ b/bids/analysis/transformations/compute.py
@@ -58,7 +58,7 @@ class Convolve(Transformation):
         # Used to compute oversampling factor to prevent information loss
         min_interval = min(np.ediff1d(np.unique(np.sort(df.onset))).min(),
                            df.duration.min())
-        oversampling = np.ceil(1 / (min_interval * sampling_rate))
+        oversampling = np.ceil(2*(1 / (min_interval * sampling_rate)))
         convolved = hrf.compute_regressor(
             vals, model, resample_frames, fir_delays=fir_delays, min_onset=0,
             oversampling=oversampling

--- a/bids/analysis/transformations/compute.py
+++ b/bids/analysis/transformations/compute.py
@@ -56,9 +56,13 @@ class Convolve(Transformation):
 
         # Minimum interval between event onsets/duration
         # Used to compute oversampling factor to prevent information loss
-        min_interval = min(np.ediff1d(np.unique(np.sort(df.onset))).min(),
-                           df.duration.min())
-        oversampling = np.ceil(2*(1 / (min_interval * sampling_rate)))
+        unique_onsets = np.unique(np.sort(df.onset))
+        if len(unique_onsets) > 1:
+            min_interval = min(np.ediff1d(unique_onsets).min(),
+                               df.duration.min())
+            oversampling = np.ceil(2*(1 / (min_interval * sampling_rate)))
+        else:
+            oversampling = 2
         convolved = hrf.compute_regressor(
             vals, model, resample_frames, fir_delays=fir_delays, min_onset=0,
             oversampling=oversampling

--- a/bids/analysis/transformations/compute.py
+++ b/bids/analysis/transformations/compute.py
@@ -56,10 +56,9 @@ class Convolve(Transformation):
 
         # Minimum interval between event onsets/duration
         # Used to compute oversampling factor to prevent information loss
-        min_interval = min(np.ediff1d(np.sort(df.onset)).min(),
+        min_interval = min(np.ediff1d(np.unique(np.sort(df.onset))).min(),
                            df.duration.min())
         oversampling = np.ceil(1 / (min_interval * sampling_rate))
-
         convolved = hrf.compute_regressor(
             vals, model, resample_frames, fir_delays=fir_delays, min_onset=0,
             oversampling=oversampling

--- a/bids/analysis/transformations/compute.py
+++ b/bids/analysis/transformations/compute.py
@@ -38,7 +38,7 @@ class Convolve(Transformation):
         if isinstance(var, SparseRunVariable):
             sampling_rate = 10
             resample_frames = np.arange(
-                0, vars.get_duration(), 1/sampling_rate)
+                0, var.get_duration(), 1/sampling_rate)
         else:
             resample_frames = df['onset'].values
             sampling_rate = var.sampling_rate

--- a/bids/analysis/transformations/compute.py
+++ b/bids/analysis/transformations/compute.py
@@ -54,6 +54,8 @@ class Convolve(Transformation):
         elif model != 'fir':
             raise ValueError("Model must be one of 'spm', 'glover', or 'fir'.")
 
+        # Minimum interval between event onsets/duration
+        # Used to compute oversampling factor to prevent information loss
         min_interval = min(np.ediff1d(np.sort(df.onset)).min(),
                            df.duration.min())
         oversampling = np.ceil(1 / (min_interval * sampling_rate))

--- a/bids/analysis/transformations/compute.py
+++ b/bids/analysis/transformations/compute.py
@@ -21,6 +21,8 @@ class Convolve(Transformation):
         dispersion (bool): Whether or not to include the dispersion derivative.
         fir_delays (iterable): A list or iterable of delays to use if model is
             'fir' (ignored otherwise). Spacing between delays must be fixed.
+        sampling_rate (float): Rate to downsample variable to after convolution
+            in Hz, if var is a SparseRunVariable.
 
     Note: Uses the HRF convolution functions implemented in nistats.
     """
@@ -29,14 +31,13 @@ class Convolve(Transformation):
     _return_type = 'variable'
 
     def _transform(self, var, model='spm', derivative=False, dispersion=False,
-                   fir_delays=None):
+                   fir_delays=None, sampling_rate=1):
 
         model = model.lower()
 
         df = var.to_df(entities=False)
 
         if isinstance(var, SparseRunVariable):
-            sampling_rate = 10
             resample_frames = np.arange(
                 0, var.get_duration(), 1/sampling_rate)
         else:

--- a/bids/analysis/transformations/compute.py
+++ b/bids/analysis/transformations/compute.py
@@ -39,8 +39,9 @@ class Convolve(Transformation):
 
         if isinstance(var, SparseRunVariable):
             sampling_rate = 10
-            resample_frames = np.arange(
-                0, var.get_duration(), 1/sampling_rate)
+            dur = var.get_duration()
+            resample_frames = np.linspace(
+                0, dur, dur * sampling_rate,  endpoint=False)
         else:
             resample_frames = df['onset'].values
             sampling_rate = var.sampling_rate
@@ -55,9 +56,9 @@ class Convolve(Transformation):
         elif model != 'fir':
             raise ValueError("Model must be one of 'spm', 'glover', or 'fir'.")
 
-        oversampling = np.ceil(
-            1 / min([np.ediff1d(var.onset).min(), var.duration.min()])
-            * (1/sampling_rate))
+        min_interval = min(np.ediff1d(np.sort(var.onset)).min(),
+                           var.duration.min())
+        oversampling = np.ceil(1 / (min_interval * sampling_rate))
 
         convolved = hrf.compute_regressor(
             vals, model, resample_frames, fir_delays=fir_delays, min_onset=0,

--- a/bids/analysis/transformations/compute.py
+++ b/bids/analysis/transformations/compute.py
@@ -2,6 +2,7 @@
 Transformations that primarily involve numerical computation on variables.
 '''
 from __future__ import division
+import math
 import numpy as np
 import pandas as pd
 from bids.utils import listify
@@ -39,7 +40,8 @@ class Convolve(Transformation):
             sampling_rate = self.collection.sampling_rate
             dur = var.get_duration()
             resample_frames = np.linspace(
-                0, dur, dur * sampling_rate, endpoint=False)
+                0, dur, int(math.ceil(dur * sampling_rate)), endpoint=False)
+
         else:
             resample_frames = df['onset'].values
             sampling_rate = var.sampling_rate

--- a/bids/analysis/transformations/compute.py
+++ b/bids/analysis/transformations/compute.py
@@ -54,8 +54,8 @@ class Convolve(Transformation):
         elif model != 'fir':
             raise ValueError("Model must be one of 'spm', 'glover', or 'fir'.")
 
-        min_interval = min(np.ediff1d(np.sort(var.onset)).min(),
-                           var.duration.min())
+        min_interval = min(np.ediff1d(np.sort(df.onset)).min(),
+                           df.duration.min())
         oversampling = np.ceil(1 / (min_interval * sampling_rate))
 
         convolved = hrf.compute_regressor(

--- a/bids/analysis/transformations/compute.py
+++ b/bids/analysis/transformations/compute.py
@@ -33,10 +33,6 @@ class Convolve(Transformation):
 
         model = model.lower()
 
-        if isinstance(var, SparseRunVariable):
-            sr = self.collection.sampling_rate
-            var = var.to_dense(sr)
-
         df = var.to_df(entities=False)
         onsets = df['onset'].values
         vals = df[['onset', 'duration', 'amplitude']].values.T
@@ -52,8 +48,14 @@ class Convolve(Transformation):
         convolved = hrf.compute_regressor(vals, model, onsets,
                                           fir_delays=fir_delays, min_onset=0)
 
-        return DenseRunVariable(name=var.name, values=convolved[0], run_info=var.run_info,
-                                source=var.source, sampling_rate=var.sampling_rate)
+        if isinstance(var, SparseRunVariable):
+            return SparseRunVariable(
+                name=var.name, values=convolved[0], onset=onsets,
+                run_info=var.run_info, source=var.source)
+        else:
+            return DenseRunVariable(
+                name=var.name, values=convolved[0], run_info=var.run_info,
+                source=var.source, sampling_rate=var.sampling_rate)
 
 
 class Demean(Transformation):

--- a/bids/analysis/transformations/compute.py
+++ b/bids/analysis/transformations/compute.py
@@ -21,8 +21,6 @@ class Convolve(Transformation):
         dispersion (bool): Whether or not to include the dispersion derivative.
         fir_delays (iterable): A list or iterable of delays to use if model is
             'fir' (ignored otherwise). Spacing between delays must be fixed.
-        sampling_rate (float): Rate to downsample variable to after convolution
-            in Hz, if var is a SparseRunVariable.
 
     Note: Uses the HRF convolution functions implemented in nistats.
     """
@@ -41,7 +39,7 @@ class Convolve(Transformation):
             sampling_rate = 10
             dur = var.get_duration()
             resample_frames = np.linspace(
-                0, dur, dur * sampling_rate,  endpoint=False)
+                0, dur, dur * sampling_rate, endpoint=False)
         else:
             resample_frames = df['onset'].values
             sampling_rate = var.sampling_rate


### PR DESCRIPTION
Fixes #354 and related to #356 

Profiling indicates that the slow function is actually `np.convolve` itself. It calls `np.correlate` which takes exponentially longer as the variable grows in length. 
![output](https://user-images.githubusercontent.com/2774448/53674148-8d2c0280-3c51-11e9-8b0d-f01c2ed3b64c.png)

(see: https://github.com/numpy/numpy/issues/1858)

The good news is that by not densifying prior to convolution things go *much* faster. 
For example, a predictor with ~850 events takes about 15ms as sparse, but 1.03s when upsampled to 10hz. 50hz takes that up to about a minute (I did the profiling on that).

The question that remains is how to downsample at the end. As it is, it will use the original onsets as the `frame_times`. That is, it will resample only at those onsets. Does that make sense? Or would uniform resampling at the TR (or some factor above that), be better? Maybe we can even do 10hz resampling, although presumably this should be the final step in `Transformations` and TR should be OK. 