### PR TITLE
ENH(OPT,TST): make test_transformations run 7 sec instead of 150 or so

### DIFF
--- a/bids/analysis/tests/test_transformations.py
+++ b/bids/analysis/tests/test_transformations.py
@@ -23,18 +23,24 @@ SUBJECTS = ['01', '02']
 NRUNS = 3
 SCAN_LENGTH = 480
 
+cached_collections = {}
+
 
 @pytest.fixture
 def collection():
-    layout_path = join(get_test_data_path(), 'ds005')
-    layout = BIDSLayout(layout_path)
-    collection = layout.get_collections('run', types=['events'],
-                                        scan_length=SCAN_LENGTH,
-                                        merge=True,
-                                        sampling_rate=10,
-                                        subject=SUBJECTS
-                                        )
-    return collection
+    if 'ds005' not in cached_collections:
+        layout_path = join(get_test_data_path(), 'ds005')
+        layout = BIDSLayout(layout_path)
+        cached_collections['ds005'] = layout.get_collections(
+            'run',
+            types=['events'],
+            scan_length=SCAN_LENGTH,
+            merge=True,
+            sampling_rate=10,
+            subject=SUBJECTS
+        )
+    # Always return a clone!
+    return cached_collections['ds005'].clone()
 
 
 @pytest.fixture


### PR DESCRIPTION
- ENH: do not hardcode numbers
- use collection only for 2 subjects out of 16 (could even be just 1 may be)
- cache the collection, i.e. not regenerate in fixture each time (I initially pushed, then killed it, then revived it fixing that side-effect - just always return a clone!)

Also in principle, if tests take proper care about cloning where needed, then no caching would be needed, fixture could get `(scope="module")` and get called only once - giving even more speed up.  But ATM some test(s) do cause inplace modifications of the collection, and I didn't want to just blindly add `.clone()` everywhere, so added it once in the fixture.  The whole test_transformations.py runs 7 sec for me now (instead of 150 originally), but I think even this is too much given that it really doesn't manipulate much of data ;)