### PR TITLE
ignore rmtree errors

### DIFF
--- a/bids/layout/tests/test_writing.py
+++ b/bids/layout/tests/test_writing.py
@@ -23,7 +23,8 @@ def tmp_bids(tmpdir_factory):
     yield tmp_bids
     shutil.rmtree(str(tmp_bids))
     # Ugly hack
-    shutil.rmtree(join(get_test_data_path(), '7t_trt', 'sub-Bob'))
+    shutil.rmtree(join(get_test_data_path(), '7t_trt', 'sub-Bob'),
+                  ignore_errors=True)
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
Not sure why the tests are failing on Python 2 all of a sudden, but rather than delve into it, I'm just turning on `ignore_errors=True` in `shutil.rmtree`, since the problem is a failure to delete a directory that doesn't exist, and everything else is passing.