### PR TITLE
ENH(DOC)+RF: unify docstring to be imperative, strip away unused kwargs to BIDSFile

### DIFF
--- a/bids/analysis/hrf.py
+++ b/bids/analysis/hrf.py
@@ -434,7 +434,7 @@ def _hrf_kernel(hrf_model, tr, oversampling=50, fir_delays=None):
 
 def compute_regressor(exp_condition, hrf_model, frame_times, con_id='cond',
                       oversampling=50, fir_delays=None, min_onset=-24):
-    """ This is the main function to convolve regressors with hrf model
+    """ Convolve regressors with hrf model (the main function of the module)
 
     Parameters
     ----------

--- a/bids/analysis/hrf.py
+++ b/bids/analysis/hrf.py
@@ -346,7 +346,7 @@ def _orthogonalize(X):
 
 
 def _regressor_names(con_name, hrf_model, fir_delays=None):
-    """ Returns a list of regressor names, computed from con-name and hrf type
+    """ Return a list of regressor names, computed from con-name and hrf type
 
     Parameters
     ----------

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -1049,7 +1049,7 @@ class BIDSLayout(object):
         return fieldmap_set
 
     def get_tr(self, derivatives=False, **filters):
-        """ Returns the scanning repetition time (TR) for one or more runs.
+        """ Return the scanning repetition time (TR) for one or more runs.
 
         Args:
             derivatives (bool): If True, also checks derivatives images.

--- a/bids/layout/models.py
+++ b/bids/layout/models.py
@@ -127,7 +127,7 @@ class BIDSFile(Base):
         'polymorphic_identity': 'file'
     }
 
-    def __init__(self, filename, derivatives=False, is_dir=False):
+    def __init__(self, filename):
         self.path = filename
         self.filename = os.path.basename(self.path)
         self.dirname = os.path.dirname(self.path)

--- a/bids/layout/models.py
+++ b/bids/layout/models.py
@@ -271,6 +271,11 @@ class BIDSFile(Base):
 
 
 class BIDSDataFile(BIDSFile):
+    """ Represents a single data file in a BIDS dataset.
+
+    Derived from `BIDSFile` and provides additional functionality such as
+    obtaining pandas DataFrame data representation (via `get_df`).
+    """
 
     __mapper_args__ = {
         'polymorphic_identity': 'data_file'
@@ -313,6 +318,11 @@ class BIDSDataFile(BIDSFile):
 
 
 class BIDSImageFile(BIDSFile):
+    """ Represents a single neuroimaging data file in a BIDS dataset.
+
+    Derived from `BIDSFile` and provides additional functionality such as
+    obtaining nibabel's image file representation (via `get_image`).
+    """
 
     __mapper_args__ = {
         'polymorphic_identity': 'image_file'
@@ -440,8 +450,7 @@ class Entity(Base):
 
 
 class Tag(Base):
-    """
-    Represents an association between a File and and Entity.
+    """ Represents an association between a File and and Entity.
 
     Args:
         file (BIDSFile): The associated BIDSFile.

--- a/bids/layout/models.py
+++ b/bids/layout/models.py
@@ -191,11 +191,11 @@ class BIDSFile(Base):
         return chain(*[collect_associations([], bf) for bf in associations])
 
     def get_metadata(self):
-        """ Returns all metadata associated with the current file. """
+        """ Return all metadata associated with the current file. """
         return self.get_entities(metadata=True)
 
     def get_entities(self, metadata=False, values='tags'):
-        """ Returns entity information for the current file.
+        """ Return entity information for the current file.
 
         Args:
             metadata (bool, None): If False (default), only entities defined
@@ -277,7 +277,7 @@ class BIDSDataFile(BIDSFile):
     }
 
     def get_df(self, include_timing=True, adjust_onset=False):
-        """ Returns the contents of a tsv file as a pandas DataFrame.
+        """ Return the contents of a tsv file as a pandas DataFrame.
 
         Args:
             include_timing (bool): If True, adds an "onset" column to dense
@@ -420,11 +420,11 @@ class Entity(Base):
         return self._astype(val)
 
     def unique(self):
-        """ Returns all unique values/levels for the current entity. """
+        """ Return all unique values/levels for the current entity. """
         return list(set(self.files.values()))
 
     def count(self, files=False):
-        """ Returns a count of unique values or files.
+        """ Return a count of unique values or files.
 
         Args:
             files (bool): When True, counts all files mapped to the Entity.

--- a/bids/layout/tests/test_models.py
+++ b/bids/layout/tests/test_models.py
@@ -180,7 +180,7 @@ def test_bidsimagefile_get_image():
     path = "synthetic/sub-01/ses-01/func/sub-01_ses-01_task-nback_run-01_bold.nii.gz"
     path = path.split('/')
     path = os.path.join(get_test_data_path(), *path)
-    bf = BIDSImageFile(path, None)
+    bf = BIDSImageFile(path)
     assert bf.get_image() is not None
     assert bf.get_image().shape == (64, 64, 64, 64)
 


### PR DESCRIPTION
That stripping might be undesired (was it left for compatibility? then having at least a comment in the code would be useful) so if needed 7d3a7294d428d2d2f43c1d2c5f9f3094e6daffe5 could be dropped