### PR TITLE
ENH: convert relative path to absolute (assuming relative from top of layout) for get_metadata

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -20,6 +20,7 @@ from .models import (Base, Config, BIDSFile, Entity, Tag, BIDSDataFile,
 from .index import BIDSLayoutIndexer
 from .. import config as cf
 
+import os.path as op
 try:
     from os.path import commonpath
 except ImportError:
@@ -856,7 +857,8 @@ class BIDSLayout(object):
             files, the values in files closer to the input filename will take
             precedence, per the inheritance rules in the BIDS specification.
         """
-
+        if path and not op.isabs(path):
+            path = op.join(self.root, path)
         for layout in self._get_layouts_in_scope(scope):
 
             query = (layout.session.query(Tag)


### PR DESCRIPTION
I am thrilled to share with you the pain of decision making (although I bet it will come quicker and more natural to you than to me ;-)).  A little bit of background for pain: In DataLad, because we provide both command line and Python APIs, we boiled down to a convention that relative paths are relative to the current directory whenever no explicit dataset (path) was provided and relative to the top of the dataset whenever that one is specified.  That allows for convenient `dataset_instance.save("modified-description")` calls within Python whenever PWD might not be under `dataset_instance` path.

Here it is somewhat of a similar situation but since it is PyBIDS (Python interface only) and there is a Layout, I think the decision might be easier since less likely use cases would demand relative paths being treated from the current directory and not from the top of the dataset.

TODOs
- [x] Get Tal's blessing or cursing
- [ ] Possibly similar path "conditioning" needs to be done in other methods, so might call for a helper or even a decorator (we have `@normalize_paths` in DataLad which we learned to love when we don't hate it) to make sure the path is in the desired "fullness".
- [ ] Testing