### PR TITLE
ENH: Add BIDSFile.__fspath__ to work with pathlib

### DIFF
--- a/bids/layout/models.py
+++ b/bids/layout/models.py
@@ -152,6 +152,9 @@ class BIDSFile(Base):
     def __repr__(self):
         return "<{} filename='{}'>".format(self.__class__.__name__, self.path)
 
+    def __fspath__(self):
+        return self.path
+
     @reconstructor
     def _init_on_load(self):
         self._data = None

--- a/bids/layout/tests/test_models.py
+++ b/bids/layout/tests/test_models.py
@@ -1,3 +1,4 @@
+import sys
 import os
 import pytest
 import bids
@@ -222,6 +223,7 @@ def test_bidsfile_get_entities(layout_synthetic):
     assert set(md.keys()) == md_ents | file_ents
 
 
+@pytest.mark.xfail(sys.version_info < (3, 6), reason="os.PathLike introduced in Python 3.6")
 def test_bidsfile_fspath(sample_bidsfile):
     bf = sample_bidsfile
     bf_path = Path(bf)

--- a/bids/layout/tests/test_models.py
+++ b/bids/layout/tests/test_models.py
@@ -2,6 +2,7 @@ import os
 import pytest
 import bids
 import copy
+from pathlib import Path
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -219,3 +220,10 @@ def test_bidsfile_get_entities(layout_synthetic):
     md2 = bf.get_entities(metadata=None)
     assert md == md2
     assert set(md.keys()) == md_ents | file_ents
+
+
+def test_bidsfile_fspath(sample_bidsfile):
+    bf = sample_bidsfile
+    bf_path = Path(bf)
+    assert bf_path == Path(bf.path)
+    assert bf_path.read_text() == '###'


### PR DESCRIPTION
This allows us to use `Path(layout.get(...)[0])`, or to pass `BIDSFile`s to functions that expect path-likes, such as `os.stat` in 3.6+, or `pandas.read_csv`.

Nothing revolutionary, but somewhat convenient when you forget that `get()` returns `BIDSFile`s.