### PR TITLE
Set name explicitly in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ ver_file = os.path.join('bids', 'version.py')
 with open(ver_file) as f:
     exec(f.read())
 
-opts = dict(name=NAME,
+opts = dict(name="pybids",
             maintainer=MAINTAINER,
             maintainer_email=MAINTAINER_EMAIL,
             description=DESCRIPTION,


### PR DESCRIPTION
Per @effigies, GitHub used-by tracking apparently doesn't work if the setup.py name is imported from somewhere else. This should hopefully fix that.