### PR TITLE
ENH: Add eeg datatype to layout config; FIX: Typo

### DIFF
--- a/bids/layout/config/bids.json
+++ b/bids/layout/config/bids.json
@@ -67,7 +67,7 @@
         },
         {
             "name": "datatype",
-            "pattern": "[/\\\\]+(func|anat|fmap|dwi|meg)[/\\\\]+s"
+            "pattern": "[/\\\\]+(func|anat|fmap|dwi|meg|eeg)[/\\\\]+"
         },
         {
             "name": "extension",


### PR DESCRIPTION
This PR fixes a typo introduced by [this commit](https://github.com/bids-standard/pybids/commit/2e532e2b76ebbab1582685f237556a761d11b669) in the `bids.json` config file.

In addition, it adds `eeg` in `datatype` to support EEG datasets. 

Note that for some reason, *channels.tsv, *electrodes.tsv, *events.tsv are not read for some reason which may be due to a different issue?

This fixes partly #454.