### PR TITLE
FIX: Instantiate ignore/force_index after root validation

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -177,18 +177,20 @@ class BIDSLayout(object):
         self.sources = sources
         self.regex_search = regex_search
         self.config_filename = config_filename
-        self.ignore = [os.path.abspath(os.path.join(self.root, patt))
-                       if isinstance(patt, six.string_types) else patt
-                       for patt in listify(ignore or [])]
-        self.force_index = [os.path.abspath(os.path.join(self.root, patt))
-                            if isinstance(patt, six.string_types) else patt
-                            for patt in listify(force_index or [])]
 
         self.database_file = database_file
         self.session = None
 
         # Do basic BIDS validation on root directory
         self._validate_root()
+
+        # Instantiate after root validation to ensure os.path.join works
+        self.ignore = [os.path.abspath(os.path.join(self.root, patt))
+                       if isinstance(patt, six.string_types) else patt
+                       for patt in listify(ignore or [])]
+        self.force_index = [os.path.abspath(os.path.join(self.root, patt))
+                            if isinstance(patt, six.string_types) else patt
+                            for patt in listify(force_index or [])]
 
         # Initialize the BIDS validator and examine ignore/force_index args
         self._validate_force_index()


### PR DESCRIPTION
If a `pathlib.Path` object is passed to `BIDSLayout` as root, then `os.path.join(root, ...)` will fail on Python <=3.5.

This change defers instantiation of `BIDSLayout.ignore` and `BIDSLayout.force_index` until after `_validate_root` coerces `BIDSLayout.root` to a `str`.