### PR TITLE
adds more sensible repr to Tag; closes #466

### DIFF
--- a/bids/layout/models.py
+++ b/bids/layout/models.py
@@ -493,7 +493,7 @@ class Tag(Base):
         self._init_on_load()
     
     def __repr__(self):
-        msg = "Tag for file '{}' with entity name '{}' has value {}."
+        msg = "<Tag file:{!r} entity:{!r} value:{!r}>"
         return msg.format(self.file_path, self.entity_name, self.value)
 
     @reconstructor

--- a/bids/layout/models.py
+++ b/bids/layout/models.py
@@ -491,6 +491,10 @@ class Tag(Base):
         self._dtype = dtype
 
         self._init_on_load()
+    
+    def __repr__(self):
+        msg = "Tag for file '{}' with entity name '{}' has value {}."
+        return msg.format(self.file_path, self.entity_name, self.value)
 
     @reconstructor
     def _init_on_load(self):

--- a/bids/layout/tests/test_models.py
+++ b/bids/layout/tests/test_models.py
@@ -97,6 +97,13 @@ def test_file_associations():
     assert set(results) == {md1, md2}
 
 
+def test_tag_init(sample_bidsfile, subject_entity):
+    f, e = sample_bidsfile, subject_entity
+    tag = Tag(f, e, 'zzz')
+    rep = str(tag)
+    assert rep.startswith("Tag for file") and f.path in rep and 'zzz' in rep
+
+
 def test_tag_dtype(sample_bidsfile, subject_entity):
     f, e = sample_bidsfile, subject_entity
     # Various ways of initializing--should all give same result

--- a/bids/layout/tests/test_models.py
+++ b/bids/layout/tests/test_models.py
@@ -101,7 +101,7 @@ def test_tag_init(sample_bidsfile, subject_entity):
     f, e = sample_bidsfile, subject_entity
     tag = Tag(f, e, 'zzz')
     rep = str(tag)
-    assert rep.startswith("Tag for file") and f.path in rep and 'zzz' in rep
+    assert rep.startswith("<Tag file:") and f.path in rep and 'zzz' in rep
 
 
 def test_tag_dtype(sample_bidsfile, subject_entity):


### PR DESCRIPTION
This doesn't actually fix #465, but it closes #466, which is independently useful. (We should probably improve the `__repr__` of other models as well at some point, but the vast majority of collisions of the kind in #465 are going to affect the `Tag` model).