### PR TITLE
MAINT: Additional Zenodo metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,4 +1,6 @@
 {
+  "title": "PyBIDS: Python tools for BIDS datasets",
+  "description": "PyBIDS is a Python library to centralize interactions with datasets conforming BIDS (Brain Imaging Data Structure) format. For more information about BIDS visit <a href=\"https://bids.neuroimaging.io\">bids.neuroimaging.io</a>.",
   "creators": [
     {
       "affiliation": "University of Texas at Austin",
@@ -187,8 +189,12 @@
     }
   ],
   "keywords": [
+    "BIDS",
+    "brain imaging data structure",
+    "neuroscience",
     "neuroimaging",
-    "BIDS"
+    "neuroinformatics",
+    "python"
   ],
   "license": "mit-license",
   "upload_type": "software"

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -133,7 +133,7 @@
       "orcid": "0000-0002-0795-1154"
     },
     {
-      "affiliation": "Université catholique de Louvain",
+      "affiliation": "Universit\u00e9 catholique de Louvain",
       "name": "Gau, Remi",
       "orcid": "0000-0002-1535-9767"
     },

--- a/tools/prep_zenodo.py
+++ b/tools/prep_zenodo.py
@@ -78,4 +78,4 @@ creators = [
     ]
 
 zenodo['creators'] = creators
-zenodo_file.write_text(json.dumps(zenodo, indent=2, sort_keys=True) + '\n')
+zenodo_file.write_text(json.dumps(zenodo, indent=2) + '\n')


### PR DESCRIPTION
The goal of this PR is to update our titles to enable the JOSS process (https://github.com/openjournals/joss-reviews/issues/1294) to finish with the next release.

* Adds a title consistent with the JOSS title
* Adds a description from README.md - this will remove the release notes from the Zenodo entry, I believe, but I'm not sure how valuable that is to Zenodo landing pages.
* Update the tags to be a bit more findable.
* Updates `tools/prep_zenodo.py` to avoid reordering title and description out of prominence.

Perhaps we want to make an RC release just to see if it works without causing everybody to upgrade a bunch while we iterate?