### PR TITLE
MAINT/CI: Use `extras_require` to declare dependencies for tests 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,9 @@ doc/generated/
 
 # Pytest
 .pytest_cache/
+
+# Vim
+.*.sw[op]
+
+# Emacs and others
+*~

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   global:
     - EXTRA_WHEELS="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
     - PRE_WHEELS="https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com"
-    - CHECK_TYPE="test"
+    - CHECK_TYPE="travis_tests"
   matrix:
     - EXTRA_PIP_FLAGS="--find-links=$EXTRA_WHEELS"
     - EXTRA_PIP_FLAGS="--pre --find-links=$EXTRA_WHEELS --find-links $PRE_WHEELS"
@@ -67,19 +67,16 @@ before_install:
     - source venv/bin/activate
     - python --version # just to check
     - travis_retry pip install -U pip setuptools wheel  # needed at one point
-    - travis_retry pip install pytest pytest-xdist pytest-cov codecov mock
-    - travis_retry pip install pathlib
 
 install:
-- pip install $EXTRA_PIP_FLAGS ".[analysis]"
-- |
-  if [ "$CHECK_TYPE" = "tutorial" ]; then
-      pip install $EXTRA_PIP_FLAGS nbconvert jupyter_client ipykernel
-  fi
+- travis_retry pip install $EXTRA_PIP_FLAGS ".[analysis]"
+
+before_script:
+- travis_retry pip install $EXTRA_PIP_FLAGS ".[$CHECK_TYPE]"
 
 script:
 - |
-  if [ "$CHECK_TYPE" = "test" ]; then
+  if [ "$CHECK_TYPE" = "travis_tests" ]; then
       py.test -n 2 -v --cov bids --cov-config .coveragerc --cov-report xml:cov.xml bids
   elif [ "$CHECK_TYPE" = "tutorial" ]; then
       jupyter nbconvert --execute examples/pybids_tutorial.ipynb

--- a/bids/version.py
+++ b/bids/version.py
@@ -47,12 +47,15 @@ PLATFORMS = "OS Independent"
 # No data for now
 REQUIRES = ["num2words", "numpy", "scipy", "pandas>=0.23.0",
             "nibabel>=2.1", "patsy", "bids-validator", "SQLAlchemy"]
+TESTS_REQUIRE = ["pytest>=3.3.0", "mock", 'pathlib; python_version < "3.4"']
 EXTRAS_REQUIRE = {
+   'test': TESTS_REQUIRE,
+   "travis_tests": TESTS_REQUIRE + ["pytest-xdist", "pytest-cov", "codecov"],
+   "tutorial": ["nbconvert", "jupyter_client", "ipykernel"],
    # Just to not break compatibility with externals requiring
    # now deprecated installation schemes
-   'analysis': []
+   'analysis': [],
 }
-TESTS_REQUIRE = ["pytest>=3.3.0", 'pathlib; python_version < "3.4"']
 
 
 def package_files(directory):


### PR DESCRIPTION
Adds `test`, `travis_tests` and `tutorial` extras to unify the installation process on Travis and reduce some of the `if`/`else` mess.

Spin-off of #470. Not really necessary, especially as what I was trying to enable isn't feasible, but I think it makes things a little cleaner, so here it is.

Threw in a `.gitignore` update.