### PR TITLE
FIX: Automatically sanitizes dtype of get() arguments

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -784,9 +784,22 @@ class BIDSLayout(object):
 
         # Entity filtering
         if filters:
+
+            # Retrieve Entity dtypes for value sanitization
+            names = list(filters.keys())
+            ents = {e.name: e for e in
+                    self.session.query(Entity)
+                        .filter(Entity.name.in_(names)).all()}
+
             query = query.join(BIDSFile.tags)
             regex = kwargs.get('regex_search', False)
             for name, val in filters.items():
+                # Try to apply Entity dtype to value. Fail silently because
+                # the DB may still know how to reconcile type differences.
+                try:
+                    val = ents[name]._astype(val)
+                except:
+                    pass
                 if isinstance(val, (list, tuple)) and len(val) == 1:
                     val = val[0]
 

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -794,7 +794,6 @@ class BIDSLayout(object):
             query = query.join(BIDSFile.tags)
             regex = kwargs.get('regex_search', False)
             for name, val in filters.items():
-                _val = val
                 # Try to apply Entity dtype to value. Fail silently because
                 # the DB may still know how to reconcile type differences.
                 try:

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -794,10 +794,14 @@ class BIDSLayout(object):
             query = query.join(BIDSFile.tags)
             regex = kwargs.get('regex_search', False)
             for name, val in filters.items():
+                _val = val
                 # Try to apply Entity dtype to value. Fail silently because
                 # the DB may still know how to reconcile type differences.
                 try:
-                    val = ents[name]._astype(val)
+                    if isinstance(val, (list, tuple)):
+                        val = [ents[name]._astype(v) for v in val]
+                    else:
+                        val = ents[name]._astype(val)
                 except:
                     pass
                 if isinstance(val, (list, tuple)) and len(val) == 1:

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -2,16 +2,20 @@
 functionality should go in the grabbit package. """
 
 import os
-import pytest
-import bids
 import re
+import tempfile
+from os.path import join, abspath, basename, dirname
+
+import numpy as np
+import pytest
+
+import bids
 from bids.layout import BIDSLayout, parse_file_entities, add_config_paths
 from bids.layout.models import (BIDSFile, BIDSImageFile, Entity, Config,
                                 FileAssociation)
-from os.path import join, abspath, basename, dirname
 from bids.tests import get_test_data_path
 from bids.utils import natural_sort
-import tempfile
+
 
 
 def test_layout_init(layout_7t_trt):
@@ -558,3 +562,11 @@ def test_indexing_tag_conflict():
         print(exc.value.message)
         assert exc.value.message.startswith("Conflicting values found")
         assert 'run' in exc.value.message
+
+
+def test_get_with_wrong_dtypes(layout_7t_trt):
+    ''' Test automatic dtype sanitization. '''
+    l = layout_7t_trt
+    assert l.get(run=1) == l.get(run='1') == l.get(run=np.int64(1))
+    assert not l.get(run='not_numeric')
+    assert l.get(session=1) == l.get(session='1')

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -567,6 +567,7 @@ def test_indexing_tag_conflict():
 def test_get_with_wrong_dtypes(layout_7t_trt):
     ''' Test automatic dtype sanitization. '''
     l = layout_7t_trt
-    assert l.get(run=1) == l.get(run='1') == l.get(run=np.int64(1))
+    assert (l.get(run=1) == l.get(run='1') == l.get(run=np.int64(1)) ==
+            l.get(run=[1, '15']))
     assert not l.get(run='not_numeric')
     assert l.get(session=1) == l.get(session='1')


### PR DESCRIPTION
Fixes #490 by automatically trying to convert every entity value passed as an argument to `BIDSLayout.get()` to the appropriate data type (as encoded in the `.dtype` field of the corresponding `Entity`). This fails silently to still allow the DB to reconcile different types.