### PR TITLE
Enforce dtypes on spec-defined columns when reading in DFs

### DIFF
--- a/bids/layout/models.py
+++ b/bids/layout/models.py
@@ -312,7 +312,7 @@ class BIDSDataFile(BIDSFile):
         # because the dtype enforcement will break if we ignore the value of
         # enforce_dtypes).
         self.data = pd.read_csv(self.path, sep='\t', na_values='n/a',
-                                    dtype=dtype)
+                                dtype=dtype)
 
         data = self.data.copy()
 

--- a/bids/layout/tests/test_models.py
+++ b/bids/layout/tests/test_models.py
@@ -187,6 +187,14 @@ def test_bidsfile_get_df_from_tsv_gz(layout_synthetic):
     assert np.allclose(df3.iloc[:,0], df1.iloc[:, 0] + 22.8)
 
 
+def test_bidsdatafile_enforces_dtype(layout_synthetic):
+    bf = layout_synthetic.get(suffix='participants', extension='tsv')[0]
+    df = bf.get_df(enforce_dtypes=False)
+    assert df.loc[:, 'subject_id'].dtype == int
+    df = bf.get_df(enforce_dtypes=True)
+    assert df.loc[:, 'subject_id'].dtype == 'O'
+
+
 def test_bidsimagefile_get_image():
     path = "synthetic/sub-01/ses-01/func/sub-01_ses-01_task-nback_run-01_bold.nii.gz"
     path = path.split('/')

--- a/bids/layout/tests/test_models.py
+++ b/bids/layout/tests/test_models.py
@@ -191,8 +191,11 @@ def test_bidsdatafile_enforces_dtype(layout_synthetic):
     bf = layout_synthetic.get(suffix='participants', extension='tsv')[0]
     df = bf.get_df(enforce_dtypes=False)
     assert df.loc[:, 'subject_id'].dtype == int
+    assert df.loc[:, 'subject_id'][0] == 1
     df = bf.get_df(enforce_dtypes=True)
     assert df.loc[:, 'subject_id'].dtype == 'O'
+    assert df.loc[:, 'subject_id'][0] == '001'
+    assert df.loc[:, 'subject_id'][1] == '2'
 
 
 def test_bidsimagefile_get_image():

--- a/bids/tests/data/synthetic/participants.tsv
+++ b/bids/tests/data/synthetic/participants.tsv
@@ -1,5 +1,5 @@
 participant_id	age	sex	subject_id
-sub-01	34	F	1
+sub-01	34	F	001
 sub-02	38	M	2
 sub-03	22	M	3
 sub-04	21	F	4

--- a/bids/tests/data/synthetic/participants.tsv
+++ b/bids/tests/data/synthetic/participants.tsv
@@ -1,6 +1,6 @@
-participant_id	age	sex
-sub-01	34	F
-sub-02	38	M
-sub-03	22	M
-sub-04	21	F
-sub-05	42	M
+participant_id	age	sex	subject_id
+sub-01	34	F	1
+sub-02	38	M	2
+sub-03	22	M	3
+sub-04	21	F	4
+sub-05	42	M	5

--- a/bids/variables/io.py
+++ b/bids/variables/io.py
@@ -365,7 +365,7 @@ def _load_tsv_variables(layout, suffix, dataset=None, columns=None,
 
     for f in files:
 
-        _data = pd.read_csv(f.path, sep='\t')
+        _data = f.get_df(include_timing=False)
 
         # Entities can be defined either within the first column of the .tsv
         # file (for entities that vary by row), or from the full file path


### PR DESCRIPTION
Ensures correct dtype enforcement for columns in files like `participants.tsv` that are defined in the spec has having a particular dtype (e.g., `subject` labels are strings).

Closes #480.