### PR TITLE
ENH: Raise ValueError if BIDSLayout.build_path fails to match any pattern

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -1204,7 +1204,7 @@ class BIDSLayout(object):
 
         built = build_path(source, path_patterns, strict)
         if built is None:
-            raise ValueError(f"Unable to construct build path with source {source}")
+            raise ValueError("Unable to construct build path with source {}".format(source))
         to_check = os.path.join(os.path.sep, built)
 
         if not validate or BIDSValidator().is_bids(to_check):

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -1203,6 +1203,8 @@ class BIDSLayout(object):
                     seen_configs.add(c)
 
         built = build_path(source, path_patterns, strict)
+        if built is None:
+            raise ValueError(f"Unable to construct build path with source {source}")
         to_check = os.path.join(os.path.sep, built)
 
         if not validate or BIDSValidator().is_bids(to_check):

--- a/bids/layout/tests/test_path_building.py
+++ b/bids/layout/tests/test_path_building.py
@@ -25,3 +25,9 @@ def test_invalid_file_construction(layout):
     
     target = "sub-01/func/sub-01_task-resting-state_run-1_bold.nii.gz"
     assert layout.build_path(ents, validate=False) == target
+
+
+def test_failed_file_construction(layout):
+    ents = dict(subject='01', fakekey='foobar')
+    with pytest.raises(ValueError):
+        layout.build_path(ents)


### PR DESCRIPTION
This will fail on the next line anyways if built is None, but at least this is more descriptive