### PR TITLE
FIX: use string dtype for all entities when using regex search

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -829,7 +829,7 @@ class BIDSLayout(object):
                         val_clause = sa.or_(*[Tag._value.op('REGEXP')(str(v))
                                               for v in val])
                     else:
-                        val_clause = Tag._value.op('REGEXP')(val)
+                        val_clause = Tag._value.op('REGEXP')(str(val))
                 else:
                     if isinstance(val, (list, tuple)):
                         val_clause = Tag._value.in_(val)

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -587,3 +587,33 @@ def test_get_with_wrong_dtypes(layout_7t_trt):
             l.get(run=[1, '15']))
     assert not l.get(run='not_numeric')
     assert l.get(session=1) == l.get(session='1')
+
+
+def test_get_with_regex_search(layout_7t_trt):
+    """ Tests that regex-based searching works. """
+    l = layout_7t_trt
+
+    # subject matches both '10' and '01'
+    results = l.get(subject='1', session='1', task='rest', suffix='bold',
+                    acquisition='fron.al', extension='nii.gz',
+                    regex_search=True)
+    assert len(results) == 2
+
+    # subject matches '10'
+    results = l.get(subject='^1', session='1', task='rest', suffix='bold',
+                    acquisition='fron.al', extension='nii.gz',
+                    regex_search=True, return_type='filename')
+    assert len(results) == 1
+    assert results[0].endswith('sub-10_ses-1_task-rest_acq-prefrontal_bold.nii.gz')
+
+
+def test_get_with_regex_search_bad_dtype(layout_7t_trt):
+    """ Tests that passing in a non-string dtype for an entity doesn't crash
+    regexp-based searching (i.e., that implicit conversion is done
+    appropriately). """
+    l = layout_7t_trt
+    results = l.get(subject='1', run=1, task='rest', suffix='bold',
+                    acquisition='fullbrain', extension='nii.gz',
+                    regex_search=True)
+    # Two runs (1 per session) for each of subjects '10' and '01'
+    assert len(results) == 4


### PR DESCRIPTION
Forces the dtype of all entities to `str` when using `regex_search=True`.

Closes #509.