### PR TITLE
Improve derivative database mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,7 @@ doc/generated/
 
 # Emacs and others
 *~
+
+# Ignore test sql database files
+bidsdb.sql
+fmriprep.sql

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -266,7 +266,7 @@ class BIDSLayout(object):
                 validate=validate, absolute_paths=absolute_paths,
                 derivatives=None, config=None, sources=self, ignore=ignore,
                 force_index=force_index, config_filename=config_filename,
-                regex_search=regex_search, reset_database=reset_database,
+                regex_search=regex_search, reset_database=index_dataset or reset_database,
                 index_metadata=index_metadata)
 
     def __getattr__(self, key):

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -241,13 +241,16 @@ class BIDSLayout(object):
             config = [Config.load(c, session=self.session)
                       for c in listify(config)]
             self.config = {c.name: c for c in config}
+            # Missing persistence of configs to the database
+            for config_obj in self.config.values():
+                self.session.add(config_obj)
+                self.session.commit()
 
             # Index files and (optionally) metadata
             indexer = BIDSLayoutIndexer(self)
             indexer.index_files()
             if index_metadata:
                 indexer.index_metadata()
-
         else:
             # Load Configs from DB
             self.config = {c.name: c for c in self.session.query(Config).all()}

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -256,8 +256,13 @@ class BIDSLayout(object):
         if derivatives:
             if derivatives is True:
                 derivatives = os.path.join(root, 'derivatives')
+            if database_file is not None:  # if creating db files for bids, also create db files for derivatives
+                create_derivative_database_files = True
+            else:
+                create_derivative_database_files = False
             self.add_derivatives(
-                derivatives, validate=validate, absolute_paths=absolute_paths,
+                derivatives, create_derivative_database_files=create_derivative_database_files,
+                validate=validate, absolute_paths=absolute_paths,
                 derivatives=None, config=None, sources=self, ignore=ignore,
                 force_index=force_index, config_filename=config_filename,
                 regex_search=regex_search, reset_database=reset_database,
@@ -593,7 +598,7 @@ class BIDSLayout(object):
         return parse_file_entities(filename, entities, config,
                                    include_unmatched)
 
-    def add_derivatives(self, path, **kwargs):
+    def add_derivatives(self, path, create_derivative_database_files=False, **kwargs):
         """Add BIDS-Derivatives datasets to tracking.
 
         Parameters
@@ -603,6 +608,10 @@ class BIDSLayout(object):
             Each path can point to either a derivatives/ directory
             containing one more more pipeline directories, or to a single
             pipeline directory (e.g., derivatives/fmriprep).
+        create_derivative_database_files : bool
+            If True, use the pipline name from the dataset_description.json
+            file as the database filename and write the file to disk in the
+            derivatives directory.
         kwargs : dict
             Optional keyword arguments to pass on to
             BIDSLayout() when initializing each of the derivative datasets.
@@ -660,6 +669,10 @@ class BIDSLayout(object):
             # Default config and sources values
             kwargs['config'] = kwargs.get('config') or ['bids', 'derivatives']
             kwargs['sources'] = kwargs.get('sources') or self
+            if create_derivative_database_files:
+                current_database_file = os.path.join(deriv, pipeline_name+".sql")
+                kwargs['database_file']=current_database_file
+
             self.derivatives[pipeline_name] = BIDSLayout(deriv, **kwargs)
 
     def to_df(self, metadata=False, **filters):

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -259,10 +259,8 @@ class BIDSLayout(object):
         if derivatives:
             if derivatives is True:
                 derivatives = os.path.join(root, 'derivatives')
-            if database_file is not None:  # if creating db files for bids, also create db files for derivatives
-                create_derivative_database_files = True
-            else:
-                create_derivative_database_files = False
+            # if creating db files for bids, also create db files for derivatives
+            create_derivative_database_files = (database_file is not None)
             self.add_derivatives(
                 derivatives, create_derivative_database_files=create_derivative_database_files,
                 validate=validate, absolute_paths=absolute_paths,

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -317,12 +317,15 @@ class BIDSLayout(object):
         self.session = sa.orm.sessionmaker(bind=engine)()
 
     def _init_db(self, database_file=None, reset_database=False):
-        self._set_session(database_file)
-
         # Reset database if needed and return whether or not it was reset
+        # determining if the database needs resetting must be done prior
+        # prior to setting the session (which creates the empty database file)
         reset_database = (reset_database or                   # Manual Request
                           not database_file or                # In memory transient database
                           not os.path.exists(database_file))  # New file based database created
+
+        self._set_session(database_file)
+
         if reset_database:
             engine = self.session.get_bind()
             Base.metadata.drop_all(engine)

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -203,7 +203,17 @@ class BIDSLayout(object):
         self.regex_search = regex_search
         self.config_filename = config_filename
 
-        self.database_file = database_file
+        def _normalize_db_name(default_root_dir, db_file):
+            if db_file is None:
+                return None
+            # If a full absolute path is given, use it, else make path
+            if not os.path.isabs(db_file):
+                db_file = os.path.abspath(os.path.join(default_root_dir, db_file))
+            return db_file
+
+        self.database_file = _normalize_db_name(self.root, database_file)
+        del database_file
+
         self.session = None
 
         # Do basic BIDS validation on root directory
@@ -223,7 +233,7 @@ class BIDSLayout(object):
         # Initialize the BIDS validator and examine ignore/force_index args
         self._validate_force_index()
 
-        index_dataset = self._init_db(database_file, reset_database)
+        index_dataset = self._init_db(self.database_file, reset_database)
 
         if index_dataset:
             # Create Config objects
@@ -288,8 +298,10 @@ class BIDSLayout(object):
         return s
 
     def _set_session(self, database_file):
-        engine = sa.create_engine('sqlite:///{}'.format(database_file))
-
+        if database_file:
+            engine = sa.create_engine('sqlite:///{filepath}'.format(filepath=database_file))
+        else:
+            engine = sa.create_engine('sqlite://') # In memory database
         def regexp(expr, item):
             """Regex function for SQLite's REGEXP."""
             reg = re.compile(expr, re.I)
@@ -303,25 +315,17 @@ class BIDSLayout(object):
         def do_begin(conn):
             conn.connection.create_function('regexp', 2, regexp)
 
-        if database_file:
-            self.database_file = os.path.relpath(database_file, self.root)
         self.session = sa.orm.sessionmaker(bind=engine)()
 
     def _init_db(self, database_file=None, reset_database=False):
-
-        if database_file is None:
-            database_file = ''
-        else:
-            database_file = os.path.join(self.root, database_file)
-            database_file = os.path.abspath(database_file)
-
-        self._set_session(database_file)
+        assert(database_file == self.database_file) # NOTE: database_file is not needed as a parameter here
+        self._set_session(self.database_file)
 
         # Reset database if needed and return whether or not it was reset
-        condi = (reset_database or
-                 not database_file or
-                 not os.path.exists(database_file))
-        if condi:
+        reset_database = (reset_database or                        # Manual Request
+                          not self.database_file or                # In memory transient database
+                          not os.path.exists(self.database_file))  # New file based database created
+        if reset_database:
             engine = self.session.get_bind()
             Base.metadata.drop_all(engine)
             Base.metadata.create_all(engine)

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -211,8 +211,7 @@ class BIDSLayout(object):
                 db_file = os.path.abspath(os.path.join(default_root_dir, db_file))
             return db_file
 
-        self.database_file = _normalize_db_name(self.root, database_file)
-        del database_file
+        database_file = _normalize_db_name(self.root, database_file)
 
         self.session = None
 
@@ -233,7 +232,7 @@ class BIDSLayout(object):
         # Initialize the BIDS validator and examine ignore/force_index args
         self._validate_force_index()
 
-        index_dataset = self._init_db(self.database_file, reset_database)
+        index_dataset = self._init_db(database_file, reset_database)
 
         if index_dataset:
             # Create Config objects
@@ -318,13 +317,12 @@ class BIDSLayout(object):
         self.session = sa.orm.sessionmaker(bind=engine)()
 
     def _init_db(self, database_file=None, reset_database=False):
-        assert(database_file == self.database_file) # NOTE: database_file is not needed as a parameter here
-        self._set_session(self.database_file)
+        self._set_session(database_file)
 
         # Reset database if needed and return whether or not it was reset
-        reset_database = (reset_database or                        # Manual Request
-                          not self.database_file or                # In memory transient database
-                          not os.path.exists(self.database_file))  # New file based database created
+        reset_database = (reset_database or                   # Manual Request
+                          not database_file or                # In memory transient database
+                          not os.path.exists(database_file))  # New file based database created
         if reset_database:
             engine = self.session.get_bind()
             Base.metadata.drop_all(engine)

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -297,10 +297,29 @@ class BIDSLayout(object):
         return s
 
     def _set_session(self, database_file):
-        if database_file:
-            engine = sa.create_engine('sqlite:///{filepath}'.format(filepath=database_file))
+        if database_file is not None:
+            # https://docs.sqlalchemy.org/en/13/dialects/sqlite.html
+            # When a file-based database is specified, the dialect will use NullPool as the source of connections. This
+            # pool closes and discards connections which are returned to the pool immediately. SQLite file-based
+            # connections have extremely low overhead, so pooling is not necessary. The scheme also prevents a
+            # connection from being used again in a different thread and works best with SQLite's coarse-grained
+            # file locking.
+            from sqlalchemy.pool import NullPool
+            engine = sa.create_engine('sqlite:///{dbfilepath}'.format(dbfilepath=database_file),
+                                      connect_args={'check_same_thread':False},
+                                      poolclass=NullPool)
         else:
-            engine = sa.create_engine('sqlite://') # In memory database
+            # https://docs.sqlalchemy.org/en/13/dialects/sqlite.html
+            # Using a Memory Database in Multiple Threads
+            # To use a :memory: database in a multithreaded scenario, the same connection object must be shared among
+            # threads, since the database exists only within the scope of that connection. The StaticPool
+            # implementation will maintain a single connection globally, and the check_same_thread flag can be passed
+            # to Pysqlite as False:
+            from sqlalchemy.pool import StaticPool
+            engine = sa.create_engine('sqlite://', # In memory database
+                                   connect_args={'check_same_thread':False},
+                                   poolclass=StaticPool)
+            # Note that using a :memory: database in multiple threads requires a recent version of SQLite.
         def regexp(expr, item):
             """Regex function for SQLite's REGEXP."""
             reg = re.compile(expr, re.I)

--- a/bids/layout/tests/conftest.py
+++ b/bids/layout/tests/conftest.py
@@ -54,3 +54,14 @@ def layout_ds005_multi_derivs():
 def layout_synthetic():
     path = join(get_test_data_path(), 'synthetic')
     return BIDSLayout(path, derivatives=True)
+
+
+@pytest.fixture(scope="module")
+def layout_synthetic_cached_db():
+    path = join(get_test_data_path(), 'synthetic')
+    return BIDSLayout(path, derivatives=True, database_file="bidsdb.sql")
+
+@pytest.fixture(scope="module")
+def layout_synthetic_cached_db_replay():
+    path = join(get_test_data_path(), 'synthetic')
+    return BIDSLayout(path, derivatives=True, database_file="bidsdb.sql")

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -471,6 +471,60 @@ def test_parse_file_entities_from_layout(layout_synthetic):
     target = {'desc': 'bleargh'}
     assert target == layout.parse_file_entities(filename, config='derivatives')
 
+def test_parse_file_entities_from_layout_cached_db(layout_synthetic_cached_db):
+    layout = layout_synthetic_cached_db
+    filename = '/sub-03_ses-07_run-4_desc-bleargh_sekret.nii.gz'
+
+    # Test with entities taken from bids config
+    target = {'subject': '03', 'session': '07', 'run': 4, 'suffix': 'sekret',
+              'extension': 'nii.gz'}
+    assert target == layout.parse_file_entities(filename, config='bids')
+    config = Config.load('bids')
+    assert target == layout.parse_file_entities(filename, config=[config])
+    assert target == layout.parse_file_entities(filename, scope='raw')
+
+    # Test with default scope--i.e., everything
+    target = {'subject': '03', 'session': '07', 'run': 4, 'suffix': 'sekret',
+              'desc': 'bleargh', 'extension': 'nii.gz'}
+    assert target == layout.parse_file_entities(filename)
+    # Test with only the fmriprep pipeline (which includes both configs)
+    assert target == layout.parse_file_entities(filename, scope='fmriprep')
+    assert target == layout.parse_file_entities(filename, scope='derivatives')
+
+    # Test with only the derivative config
+    target = {'desc': 'bleargh'}
+    assert target == layout.parse_file_entities(filename, config='derivatives')
+
+
+def test_parse_file_entities_from_layout_cached_db_replay(layout_synthetic_cached_db_replay):
+    """
+    We need to ensure that after caching the database requesting cached values
+    provides all the original values.
+    :param layout_synthetic_cached_db_replay:
+    """
+    layout = layout_synthetic_cached_db_replay
+    filename = '/sub-03_ses-07_run-4_desc-bleargh_sekret.nii.gz'
+
+    # Test with entities taken from bids config
+    target = {'subject': '03', 'session': '07', 'run': 4, 'suffix': 'sekret',
+              'extension': 'nii.gz'}
+    assert target == layout.parse_file_entities(filename, config='bids')
+    config = Config.load('bids')
+    assert target == layout.parse_file_entities(filename, config=[config])
+    assert target == layout.parse_file_entities(filename, scope='raw')
+
+    # Test with default scope--i.e., everything
+    target = {'subject': '03', 'session': '07', 'run': 4, 'suffix': 'sekret',
+              'desc': 'bleargh', 'extension': 'nii.gz'}
+    assert target == layout.parse_file_entities(filename)
+    # Test with only the fmriprep pipeline (which includes both configs)
+    assert target == layout.parse_file_entities(filename, scope='fmriprep')
+    assert target == layout.parse_file_entities(filename, scope='derivatives')
+
+    # Test with only the derivative config
+    target = {'desc': 'bleargh'}
+    assert target == layout.parse_file_entities(filename, config='derivatives')
+
 
 def test_deriv_indexing():
     data_dir = join(get_test_data_path(), 'ds005')


### PR DESCRIPTION
After a derivative directory has been created, storing a persistent sqllite database file on disk can dramatically improve subsequent queries.

In my current test case with 25808 files in the derivative directory, basic startup commands for creating the layout move from '98.77 seconds' to '0.03 seconds' needed to initialize the layout for querying.

```python
import time
import sys
from bids import BIDSLayout

bids_dir = "/Users/johnsonhj/data/MediumTestingData/"

start_time = time.time()
layout = BIDSLayout(
    bids_dir,
    database_file="bidsdb.sql",
    derivatives=["/Users/johnsonhj/data/MediumTestingData/derivative_outputs_nonstandard_derivative_directory"],
)
end_time = time.time()
elapsed = end_time - start_time
print("{0:.2f} seconds".format(elapsed))
all = layout.get(scope="derivatives", return_type="file")
print(len(all))
sys.exit()
```