### PR TITLE
fix: filter before downsampling

### DIFF
--- a/bids/variables/tests/test_variables.py
+++ b/bids/variables/tests/test_variables.py
@@ -204,7 +204,7 @@ def test_resampling_edge_case(tmpdir, TR, nvols):
     assert regressor.shape == (nvols, 1)
 
 
-def test_downsampling(tmpdir, TR, newTR, nvols, newvols):
+def test_downsampling(tmpdir):
     tmpdir.chdir()
     os.makedirs('sub-01/func')
     import numpy as np

--- a/bids/variables/tests/test_variables.py
+++ b/bids/variables/tests/test_variables.py
@@ -218,7 +218,7 @@ def test_downsampling(tmpdir, TR, newTR, nvols, newvols):
     dataobj = np.zeros((5, 5, 5, nvols), dtype=np.int16)
     Fs = 1/TR
     t = np.linspace(0, int(nvols / Fs), nvols, endpoint=False)
-    dataobj[3, 3, 3, :] = np.sin(2*np.pi*0.15*t)
+    dataobj[3, 3, 3, :] = np.sin(0.025*2*np.pi*t) + np.cos(0.1166*2*np.pi*t)
     affine = np.diag((2.5, 2.5, 2.5, 1))
     img = nb.Nifti1Image(dataobj, affine)
     img.header.set_zooms((2.5, 2.5, 2.5, TR))

--- a/bids/variables/tests/test_variables.py
+++ b/bids/variables/tests/test_variables.py
@@ -204,13 +204,11 @@ def test_resampling_edge_case(tmpdir, TR, nvols):
     assert regressor.shape == (nvols, 1)
 
 
-@pytest.mark.parametrize(
-    "TR, newTR, nvols, newvols",
-    [(2.00000, 6.0, 90, 30),])
 def test_downsampling(tmpdir, TR, newTR, nvols, newvols):
     tmpdir.chdir()
     os.makedirs('sub-01/func')
     import numpy as np
+    TR, newTR, nvols, newvols = 2.00000, 6.0, 90, 30
     Fs = 1 / TR
     t = np.linspace(0, int(nvols / Fs), nvols, endpoint=False)
     values = np.sin(0.025 * 2 * np.pi * t) + np.cos(0.1166 * 2 * np.pi * t)
@@ -232,7 +230,12 @@ def test_downsampling(tmpdir, TR, newTR, nvols, newvols):
     dense_var = coll.variables['val'].to_dense(1.0 / TR)
     regressor = dense_var.resample(1.0 / newTR).values
     assert regressor.shape == (newvols, 1)
+    # This checks that the filtering has happened. If it has not, then
+    # this value for this frequency bin will be an alias and have a
+    # very different amplitude
     assert np.allclose(np.abs(np.fft.fft(regressor.values.ravel()))[9],
                        0.46298273)
+    # This checks that the signal (0.025 Hz) within the new Nyquist
+    # rate actually gets passed through.
     assert np.allclose(np.abs(np.fft.fft(regressor.values.ravel()))[4],
                        8.88189504)

--- a/bids/variables/tests/test_variables.py
+++ b/bids/variables/tests/test_variables.py
@@ -217,8 +217,8 @@ def test_downsampling(tmpdir, TR, newTR, nvols, newvols):
 
     dataobj = np.zeros((5, 5, 5, nvols), dtype=np.int16)
     Fs = 1/TR
-    x = np.arange(nvols)
-    dataobj[3, 3, 3, :] = np.sin(2*np.pi*0.2*x*Fs)
+    t = np.linspace(0, int(nvols / Fs), nvols, endpoint=False)
+    dataobj[3, 3, 3, :] = np.sin(2*np.pi*0.15*t)
     affine = np.diag((2.5, 2.5, 2.5, 1))
     img = nb.Nifti1Image(dataobj, affine)
     img.header.set_zooms((2.5, 2.5, 2.5, TR))

--- a/bids/variables/variables.py
+++ b/bids/variables/variables.py
@@ -512,8 +512,17 @@ class DenseRunVariable(BIDSVariable):
         x = np.arange(n)
         num = len(self.index)
 
+        if sampling_rate < self.sampling_rate:
+            # Downsampling, so filter the signal
+            from scipy.signal import butter, filtfilt
+            b, a = butter(5, (sampling_rate / 2) / (self.sampling_rate / 2),
+                          btype='low', output='ba', analog=False)
+            y = filtfilt(b, a, self.values.values.ravel())
+        else:
+            y = self.values.values.ravel()
+
         from scipy.interpolate import interp1d
-        f = interp1d(x, self.values.values.ravel(), kind=kind)
+        f = interp1d(x, y, kind=kind)
         x_new = np.linspace(0, n - 1, num=num)
         self.values = pd.DataFrame(f(x_new))
         assert len(self.values) == len(self.index)

--- a/bids/variables/variables.py
+++ b/bids/variables/variables.py
@@ -515,7 +515,7 @@ class DenseRunVariable(BIDSVariable):
         if sampling_rate < self.sampling_rate:
             # Downsampling, so filter the signal
             from scipy.signal import butter, filtfilt
-            b, a = butter(5, (sampling_rate / 2) / (self.sampling_rate / 2),
+            b, a = butter(5, (sampling_rate / 2.0) / (self.sampling_rate / 2.0),
                           btype='low', output='ba', analog=False)
             y = filtfilt(b, a, self.values.values.ravel())
         else:

--- a/bids/variables/variables.py
+++ b/bids/variables/variables.py
@@ -515,6 +515,7 @@ class DenseRunVariable(BIDSVariable):
         if sampling_rate < self.sampling_rate:
             # Downsampling, so filter the signal
             from scipy.signal import butter, filtfilt
+            # cutoff = new Nyqist / old Nyquist
             b, a = butter(5, (sampling_rate / 2.0) / (self.sampling_rate / 2.0),
                           btype='low', output='ba', analog=False)
             y = filtfilt(b, a, self.values.values.ravel())


### PR DESCRIPTION
hopefully this will address #373 

however, before this is merged, i need to understand some bids fu. why is shape (nvols, 1) in the test? is only 1 timeseries being extracted from the image array?

my plan was to insert a sin wave between the nyqist freq of the original rate and the nyqist freq of the new rate. if you don't lowpass the signal prior to interpolation, then the original freq will get aliased in. so the test would check if the amplitude of the expected alias is close to 0 or not. 