### PR TITLE
STYLE: .sql is a misleading extension to sqlite files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,5 +110,5 @@ doc/generated/
 *~
 
 # Ignore test sql database files
-bidsdb.sql
-fmriprep.sql
+bidsdb.sqlite
+fmriprep.sqlite

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -672,7 +672,7 @@ class BIDSLayout(object):
             kwargs['config'] = kwargs.get('config') or ['bids', 'derivatives']
             kwargs['sources'] = kwargs.get('sources') or self
             if create_derivative_database_files:
-                current_database_file = os.path.join(deriv, pipeline_name + ".sql")
+                current_database_file = os.path.join(deriv, pipeline_name + ".sqlite")
                 kwargs['database_file'] = current_database_file
 
             self.derivatives[pipeline_name] = BIDSLayout(deriv, **kwargs)

--- a/bids/layout/tests/conftest.py
+++ b/bids/layout/tests/conftest.py
@@ -59,9 +59,9 @@ def layout_synthetic():
 @pytest.fixture(scope="module")
 def layout_synthetic_cached_db():
     path = join(get_test_data_path(), 'synthetic')
-    return BIDSLayout(path, derivatives=True, database_file="bidsdb.sql")
+    return BIDSLayout(path, derivatives=True, database_file="bidsdb.sqlite")
 
 @pytest.fixture(scope="module")
 def layout_synthetic_cached_db_replay():
     path = join(get_test_data_path(), 'synthetic')
-    return BIDSLayout(path, derivatives=True, database_file="bidsdb.sql")
+    return BIDSLayout(path, derivatives=True, database_file="bidsdb.sqlite")


### PR DESCRIPTION
Files with .sql extention are expected to have SQL code in them. The
binary data files written by sqlite should have an appropriate .sqlite
extention.