### PR TITLE
Save BIDSLayout + Derivatives to folder (with init arguments)

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -209,7 +209,7 @@ class BIDSLayout(object):
         if database_file is not None:
             database_path = database_file
             warnings.warn(
-                'In pybids 0.10 database_file argument was deprecated in favor'
+                'In pybids 0.10 database_file argument was deprecated in favor '
                 'of database_path, and will and will be removed in 0.12.'
                 'For now, treating database_file as a diretory',
                 DeprecationWarning)

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -210,7 +210,7 @@ class BIDSLayout(object):
             database_path = database_file
             warnings.warn(
                 'In pybids 0.10 database_file argument was deprecated in favor '
-                'of database_path, and will and will be removed in 0.12.'
+                'of database_path, and will and will be removed in 0.12. '
                 'For now, treating database_file as a diretory',
                 DeprecationWarning)
         if database_path:

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -353,10 +353,13 @@ class BIDSLayout(object):
         )
 
         # Prepare instance arguments for serialization
-        instance_args = self.__dict__.copy()
+        instance_args = {
+            a: self.__dict__[a] for a in
+            ['root', 'validate', 'absolute_paths', 'regex_search', 'config_file']
+            if a in self.__dict__
+        }
         for k in ['ignore', 'force_index']:
-            instance_args[k] = [str(a) for a in instance_args[k]]
-        instance_args.pop('sources', None)
+            instance_args[k] = [str(a) for a in self.__dict__[k]]
 
         self._set_session(database_file)
 
@@ -366,14 +369,15 @@ class BIDSLayout(object):
                 if saved_args[k] != v:
                     raise ValueError(
                         "Initaliation arguments do not match for database dir:"
-                        f" {database_dir}"
+                        " {}".format(database_dir)
                         )
         else:
-            if database_sidecar is not None:
-                json.dump(instance_args, open(database_sidecar, 'w'))
             engine = self.session.get_bind()
             Base.metadata.drop_all(engine)
             Base.metadata.create_all(engine)
+
+            if database_sidecar is not None:
+                json.dump(instance_args, open(database_sidecar, 'w'))
 
             # Write out arguments to json sidecar
             return True

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -339,13 +339,16 @@ class BIDSLayout(object):
             database_file = os.path.join(database_dir, 'layout_index.sqlilte')
             os.makedirs(database_dir, exist_ok=True)
             database_sidecar = os.path.join(database_dir, 'layout_args.json')
+        else:
+            database_file = None
+            database_sidecar = None
 
         # Reset database if needed and return whether or not it was reset
         # determining if the database needs resetting must be done prior
         # to setting the session (which creates the empty database file)
         reset_database = (
             reset_database or  # Manual Request
-            not database_file or  # In memory transient db
+            not database_dir or  # In memory transient db
             not os.path.exists(database_file)  # New file based db created
         )
 
@@ -366,7 +369,8 @@ class BIDSLayout(object):
                         f" {database_dir}"
                         )
         else:
-            json.dump(instance_args, open(database_sidecar, 'w'))
+            if database_sidecar is not None:
+                json.dump(instance_args, open(database_sidecar, 'w'))
             engine = self.session.get_bind()
             Base.metadata.drop_all(engine)
             Base.metadata.create_all(engine)

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -178,7 +178,7 @@ class BIDSLayout(object):
         an in-memory SQLite database is used, and the index will not
         persist unless .save() is explicitly called.
     reset_database : bool
-        If True, any existing folder specified in the
+        If True, any existing directory specified in the
         database_path argument is deleted, and the BIDS dataset provided
         in the root argument is reindexed. If False, indexing will be
         skipped and the existing database file will be used. Ignored if

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -10,6 +10,7 @@ import copy
 import warnings
 import sqlite3
 import enum
+from pathlib import Path
 
 import sqlalchemy as sa
 from sqlalchemy.orm import joinedload

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -214,7 +214,7 @@ class BIDSLayout(object):
                 'For now, treating database_file as a directory.',
                 DeprecationWarning)
         if database_path:
-            database_path = os.path.abspath(database_path)
+            database_path = str(Path(database_path).absolute())
 
         self.session = None
 

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -205,9 +205,10 @@ class BIDSLayout(object):
         if database_file is not None:
             database_dir = database_file
             warnings.warn(
-                'database_file argument is deprecated, and will be removed'
-                ' in 0.12. Use database_dir, instead. For now, treating '
-                'database_file as a diretory', DeprecationWarning)
+                'In pybids 0.10 database_file argument was deprecated in favor'
+                'of database_dir, and will and will be removed in 0.12.'
+                'For now, treating database_file as a diretory',
+                DeprecationWarning)
         if database_dir:
             database_dir = os.path.abspath(database_dir)
 
@@ -821,7 +822,7 @@ class BIDSLayout(object):
             filters['extension'] = filters.pop('extensions')
             warnings.warn("In pybids 0.9.0, the 'extensions' filter was "
                           "deprecated in favor of 'extension'. The former will"
-                          " stop working in 0.11.0.")
+                          " stop working in 0.11.0.", DeprecationWarning)
 
         layouts = self._get_layouts_in_scope(scope)
 

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -211,7 +211,7 @@ class BIDSLayout(object):
             warnings.warn(
                 'In pybids 0.10 database_file argument was deprecated in favor '
                 'of database_path, and will and will be removed in 0.12. '
-                'For now, treating database_file as a diretory',
+                'For now, treating database_file as a directory.',
                 DeprecationWarning)
         if database_path:
             database_path = os.path.abspath(database_path)

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -191,8 +191,8 @@ class BIDSLayout(object):
     def __init__(self, root, validate=True, absolute_paths=True,
                  derivatives=False, config=None, sources=None, ignore=None,
                  force_index=None, config_filename='layout_config.json',
-                 regex_search=False, database_dir=None, reset_database=False,
-                 index_metadata=True):
+                 regex_search=False, database_dir=None, database_file=None,
+                 reset_database=False, index_metadata=True):
         """Initialize BIDSLayout."""
         self.root = root
         self.validate = validate
@@ -202,6 +202,12 @@ class BIDSLayout(object):
         self.regex_search = regex_search
         self.config_filename = config_filename
 
+        if database_file is not None:
+            database_dir = database_file
+            warnings.warn(
+                'database_file argument is deprecated, and will be removed'
+                ' in 0.12. Use database_dir, instead. For now, treating '
+                'database_file as a diretory', DeprecationWarning)
         if database_dir:
             database_dir = os.path.abspath(database_dir)
 

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -388,7 +388,7 @@ class BIDSLayout(object):
             engine = self.session.get_bind()
             Base.metadata.drop_all(engine)
             Base.metadata.create_all(engine)
-            self._dump_initalization_args(database_sidecar)
+            json.dump(instance_args, open(database_sidecar, 'w'))
 
             return True
 

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -399,7 +399,8 @@ class BIDSLayout(object):
             engine = self.session.get_bind()
             Base.metadata.drop_all(engine)
             Base.metadata.create_all(engine)
-            json.dump(instance_args, open(database_sidecar, 'w'))
+            if database_sidecar:
+                json.dump(instance_args, open(database_sidecar, 'w'))
 
             return True
 

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -388,13 +388,14 @@ class BIDSLayout(object):
         instance_args = self._sanitize_instance_args()
 
         if not reset_database:
-            saved_args = json.load(open(database_sidecar))
-            for k, v in saved_args.items():
-                if instance_args[k] != v:
-                    raise ValueError(
-                        "Initialization arguments do not match for database_path:"
-                        " {}".format(database_path)
-                        )
+            with open(database_sidecar) as fobj:
+                saved_args = json.load(fobj)
+                for k, v in saved_args.items():
+                    if instance_args[k] != v:
+                        raise ValueError(
+                            "Initialization arguments do not match for database_path:"
+                            " {}".format(database_path)
+                            )
         else:
             engine = self.session.get_bind()
             Base.metadata.drop_all(engine)

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -391,12 +391,12 @@ class BIDSLayout(object):
         if not reset_database:
             with open(database_sidecar) as fobj:
                 saved_args = json.load(fobj)
-                for k, v in saved_args.items():
-                    if instance_args[k] != v:
-                        raise ValueError(
-                            "Initialization arguments do not match for database_path:"
-                            " {}".format(database_path)
-                            )
+            for k, v in saved_args.items():
+                if instance_args[k] != v:
+                    raise ValueError(
+                        "Initialization arguments do not match for database_path:"
+                        " {}".format(database_path)
+                        )
         else:
             engine = self.session.get_bind()
             Base.metadata.drop_all(engine)

--- a/bids/layout/tests/conftest.py
+++ b/bids/layout/tests/conftest.py
@@ -1,7 +1,7 @@
 from os.path import join
 
 import pytest
-
+import tempfile
 from bids.layout import BIDSLayout
 from bids.tests import get_test_data_path
 
@@ -40,11 +40,16 @@ def layout_ds005_derivs():
     return layout
 
 
+fdir = tempfile.mkdtemp()
+
 @pytest.fixture(scope="module",
-                params=[None, "bidsdb.sqlite", "bidsdb.sqlite"])
-def layout_ds005_multi_derivs(database_file):
+                params=[None, "bidsdb", "bidsdb"])
+def layout_ds005_multi_derivs(request):
     data_dir = join(get_test_data_path(), 'ds005')
-    layout = BIDSLayout(data_dir, database_file=database_file)
+    database_dir = join(fdir, request.param) if request.param else None
+
+    layout = BIDSLayout(data_dir,
+                        database_dir=database_dir)
     deriv_dir1 = join(get_test_data_path(), 'ds005_derivs')
     deriv_dir2 = join(data_dir, 'derivatives', 'events')
     layout.add_derivatives([deriv_dir1, deriv_dir2])
@@ -52,7 +57,9 @@ def layout_ds005_multi_derivs(database_file):
 
 
 @pytest.fixture(
-    scope="module", params=[None, "bidsdb.sqlite", "bidsdb.sqlite"])
-def layout_synthetic(database_file):
+    scope="module", params=[None, "bidsdb-synth", "bidsdb-synth"])
+def layout_synthetic(request):
     path = join(get_test_data_path(), 'synthetic')
-    return BIDSLayout(path, derivatives=True, database_file=database_file)
+    database_dir = join(fdir, request.param) if request.param else None
+    return BIDSLayout(path, derivatives=True,
+                      database_dir=database_dir)

--- a/bids/layout/tests/conftest.py
+++ b/bids/layout/tests/conftest.py
@@ -48,20 +48,3 @@ def layout_ds005_multi_derivs():
     deriv_dir2 = join(data_dir, 'derivatives', 'events')
     layout.add_derivatives([deriv_dir1, deriv_dir2])
     return layout
-
-
-@pytest.fixture(scope="module")
-def layout_synthetic():
-    path = join(get_test_data_path(), 'synthetic')
-    return BIDSLayout(path, derivatives=True)
-
-
-@pytest.fixture(scope="module")
-def layout_synthetic_cached_db():
-    path = join(get_test_data_path(), 'synthetic')
-    return BIDSLayout(path, derivatives=True, database_file="bidsdb.sqlite")
-
-@pytest.fixture(scope="module")
-def layout_synthetic_cached_db_replay():
-    path = join(get_test_data_path(), 'synthetic')
-    return BIDSLayout(path, derivatives=True, database_file="bidsdb.sqlite")

--- a/bids/layout/tests/conftest.py
+++ b/bids/layout/tests/conftest.py
@@ -40,11 +40,19 @@ def layout_ds005_derivs():
     return layout
 
 
-@pytest.fixture(scope="module")
-def layout_ds005_multi_derivs():
+@pytest.fixture(scope="module",
+                params=[None, "bidsdb.sqlite", "bidsdb.sqlite"])
+def layout_ds005_multi_derivs(database_file):
     data_dir = join(get_test_data_path(), 'ds005')
-    layout = BIDSLayout(data_dir)
+    layout = BIDSLayout(data_dir, database_file=database_file)
     deriv_dir1 = join(get_test_data_path(), 'ds005_derivs')
     deriv_dir2 = join(data_dir, 'derivatives', 'events')
     layout.add_derivatives([deriv_dir1, deriv_dir2])
     return layout
+
+
+@pytest.fixture(
+    scope="module", params=[None, "bidsdb.sqlite", "bidsdb.sqlite"])
+def layout_synthetic(database_file):
+    path = join(get_test_data_path(), 'synthetic')
+    return BIDSLayout(path, derivatives=True, database_file=database_file)

--- a/bids/layout/tests/conftest.py
+++ b/bids/layout/tests/conftest.py
@@ -40,13 +40,17 @@ def layout_ds005_derivs():
     return layout
 
 
-fdir = tempfile.mkdtemp()
+@pytest.fixture(scope="session")
+def db_dir(tmpdir_factory):
+    fn = tmpdir_factory.mktemp("data")
+    return fn
+
 
 @pytest.fixture(scope="module",
                 params=[None, "bidsdb", "bidsdb"])
-def layout_ds005_multi_derivs(request):
+def layout_ds005_multi_derivs(request, db_dir):
     data_dir = join(get_test_data_path(), 'ds005')
-    database_path = join(fdir, request.param) if request.param else None
+    database_path = str(db_dir / request.param) if request.param else None
 
     layout = BIDSLayout(data_dir,
                         database_path=database_path)
@@ -58,8 +62,8 @@ def layout_ds005_multi_derivs(request):
 
 @pytest.fixture(
     scope="module", params=[None, "bidsdb-synth", "bidsdb-synth"])
-def layout_synthetic(request):
+def layout_synthetic(request, db_dir):
     path = join(get_test_data_path(), 'synthetic')
-    database_path = join(fdir, request.param) if request.param else None
+    database_path = str(db_dir / request.param) if request.param else None
     return BIDSLayout(path, derivatives=True,
                       database_path=database_path)

--- a/bids/layout/tests/conftest.py
+++ b/bids/layout/tests/conftest.py
@@ -46,10 +46,10 @@ fdir = tempfile.mkdtemp()
                 params=[None, "bidsdb", "bidsdb"])
 def layout_ds005_multi_derivs(request):
     data_dir = join(get_test_data_path(), 'ds005')
-    database_dir = join(fdir, request.param) if request.param else None
+    database_path = join(fdir, request.param) if request.param else None
 
     layout = BIDSLayout(data_dir,
-                        database_dir=database_dir)
+                        database_path=database_path)
     deriv_dir1 = join(get_test_data_path(), 'ds005_derivs')
     deriv_dir2 = join(data_dir, 'derivatives', 'events')
     layout.add_derivatives([deriv_dir1, deriv_dir2])
@@ -60,6 +60,6 @@ def layout_ds005_multi_derivs(request):
     scope="module", params=[None, "bidsdb-synth", "bidsdb-synth"])
 def layout_synthetic(request):
     path = join(get_test_data_path(), 'synthetic')
-    database_dir = join(fdir, request.param) if request.param else None
+    database_path = join(fdir, request.param) if request.param else None
     return BIDSLayout(path, derivatives=True,
-                      database_dir=database_dir)
+                      database_path=database_path)

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -573,7 +573,7 @@ def test_indexed_file_associations(layout_7t_trt):
 
 def test_layout_save(layout_7t_trt):
     fdir = tempfile.mkdtemp()
-    layout_7t_trt.save(os.path.join(fdir, "f.sqlite"),
+    layout_7t_trt.save(str(tmp_path / "f.sqlite"),
                        replace_connection=False)
     data_dir = join(get_test_data_path(), '7t_trt')
     layout = BIDSLayout(data_dir, database_path=str(tmp_path))

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -572,7 +572,6 @@ def test_indexed_file_associations(layout_7t_trt):
 
 
 def test_layout_save(layout_7t_trt):
-    fdir = tempfile.mkdtemp()
     layout_7t_trt.save(str(tmp_path / "f.sqlite"),
                        replace_connection=False)
     data_dir = join(get_test_data_path(), '7t_trt')

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -11,11 +11,9 @@ import pytest
 
 import bids
 from bids.layout import BIDSLayout, parse_file_entities, add_config_paths
-from bids.layout.models import (BIDSFile, BIDSImageFile, Entity, Config,
-                                FileAssociation)
+from bids.layout.models import Entity, Config
 from bids.tests import get_test_data_path
 from bids.utils import natural_sort
-
 
 
 def test_layout_init(layout_7t_trt):
@@ -59,7 +57,7 @@ def test_get_file(layout_ds005_derivs):
     assert not layout.get_file(target, scope='derivatives')
 
     # absolute path in BIDS-Raw
-    target = (layout.root + '/' +  orig_file).split('/')
+    target = (layout.root + '/' + orig_file).split('/')
     target = os.path.sep + os.path.join(*target)
     assert layout.get_file(target)
     assert layout.get_file(target, scope='raw')
@@ -73,7 +71,7 @@ def test_get_file(layout_ds005_derivs):
     assert layout.get_file(target, scope='derivatives')
 
     # absolute path in derivatives pipeline
-    target = (layout.root + '/' +  orig_file).split('/')
+    target = (layout.root + '/' + orig_file).split('/')
     target = os.path.sep + os.path.join(*target)
     assert layout.get_file(target)
     assert not layout.get_file(target, scope='raw')
@@ -447,11 +445,8 @@ def test_parse_file_entities():
     assert target == parse_file_entities(filename, entities=entities)
 
 
-@pytest.mark.parametrize("database_file",
-                         [None, "bidsdb.sqlite", "bidsdb.sqlite"])
-def test_parse_file_entities_from_layout(database_file):
-    path = join(get_test_data_path(), 'synthetic')
-    layout = BIDSLayout(path, derivatives=True, database_file=database_file)
+def test_parse_file_entities_from_layout(layout_synthetic):
+    layout = layout_synthetic
     filename = '/sub-03_ses-07_run-4_desc-bleargh_sekret.nii.gz'
 
     # Test with entities taken from bids config

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -571,7 +571,7 @@ def test_indexed_file_associations(layout_7t_trt):
     assert not js.get_associations('InformedBy')
 
 
-def test_layout_save(layout_7t_trt):
+def test_layout_save(tmp_path, layout_7t_trt):
     layout_7t_trt.save(str(tmp_path / "f.sqlite"),
                        replace_connection=False)
     data_dir = join(get_test_data_path(), '7t_trt')

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -576,7 +576,7 @@ def test_layout_save(layout_7t_trt):
     layout_7t_trt.save(os.path.join(fdir, "f.sqlite"),
                        replace_connection=False)
     data_dir = join(get_test_data_path(), '7t_trt')
-    layout = BIDSLayout(data_dir, database_path=fdir)
+    layout = BIDSLayout(data_dir, database_path=str(tmp_path))
     oldfies = set(layout_7t_trt.get(suffix='events', return_type='file'))
     newfies = set(layout.get(suffix='events', return_type='file'))
     assert oldfies == newfies

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -447,62 +447,11 @@ def test_parse_file_entities():
     assert target == parse_file_entities(filename, entities=entities)
 
 
-def test_parse_file_entities_from_layout(layout_synthetic):
-    layout = layout_synthetic
-    filename = '/sub-03_ses-07_run-4_desc-bleargh_sekret.nii.gz'
-
-    # Test with entities taken from bids config
-    target = {'subject': '03', 'session': '07', 'run': 4, 'suffix': 'sekret',
-              'extension': 'nii.gz'}
-    assert target == layout.parse_file_entities(filename, config='bids')
-    config = Config.load('bids')
-    assert target == layout.parse_file_entities(filename, config=[config])
-    assert target == layout.parse_file_entities(filename, scope='raw')
-
-    # Test with default scope--i.e., everything
-    target = {'subject': '03', 'session': '07', 'run': 4, 'suffix': 'sekret',
-              'desc': 'bleargh', 'extension': 'nii.gz'}
-    assert target == layout.parse_file_entities(filename)
-    # Test with only the fmriprep pipeline (which includes both configs)
-    assert target == layout.parse_file_entities(filename, scope='fmriprep')
-    assert target == layout.parse_file_entities(filename, scope='derivatives')
-
-    # Test with only the derivative config
-    target = {'desc': 'bleargh'}
-    assert target == layout.parse_file_entities(filename, config='derivatives')
-
-def test_parse_file_entities_from_layout_cached_db(layout_synthetic_cached_db):
-    layout = layout_synthetic_cached_db
-    filename = '/sub-03_ses-07_run-4_desc-bleargh_sekret.nii.gz'
-
-    # Test with entities taken from bids config
-    target = {'subject': '03', 'session': '07', 'run': 4, 'suffix': 'sekret',
-              'extension': 'nii.gz'}
-    assert target == layout.parse_file_entities(filename, config='bids')
-    config = Config.load('bids')
-    assert target == layout.parse_file_entities(filename, config=[config])
-    assert target == layout.parse_file_entities(filename, scope='raw')
-
-    # Test with default scope--i.e., everything
-    target = {'subject': '03', 'session': '07', 'run': 4, 'suffix': 'sekret',
-              'desc': 'bleargh', 'extension': 'nii.gz'}
-    assert target == layout.parse_file_entities(filename)
-    # Test with only the fmriprep pipeline (which includes both configs)
-    assert target == layout.parse_file_entities(filename, scope='fmriprep')
-    assert target == layout.parse_file_entities(filename, scope='derivatives')
-
-    # Test with only the derivative config
-    target = {'desc': 'bleargh'}
-    assert target == layout.parse_file_entities(filename, config='derivatives')
-
-
-def test_parse_file_entities_from_layout_cached_db_replay(layout_synthetic_cached_db_replay):
-    """
-    We need to ensure that after caching the database requesting cached values
-    provides all the original values.
-    :param layout_synthetic_cached_db_replay:
-    """
-    layout = layout_synthetic_cached_db_replay
+@pytest.mark.parametrize("database_file",
+                         [None, "bidsdb.sqlite", "bidsdb.sqlite"])
+def test_parse_file_entities_from_layout(database_file):
+    path = join(get_test_data_path(), 'synthetic')
+    layout = BIDSLayout(path, derivatives=True, database_file=database_file)
     filename = '/sub-03_ses-07_run-4_desc-bleargh_sekret.nii.gz'
 
     # Test with entities taken from bids config

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -10,7 +10,8 @@ import numpy as np
 import pytest
 
 import bids
-from bids.layout import BIDSLayout, parse_file_entities, add_config_paths
+from bids.layout import (BIDSLayout, parse_file_entities, add_config_paths,
+                         Query)
 from bids.layout.models import Entity, Config
 from bids.tests import get_test_data_path
 from bids.utils import natural_sort
@@ -133,8 +134,8 @@ def test_get_metadata_meg(layout_ds117):
 def test_get_metadata5(layout_7t_trt):
     target = 'sub-01/ses-1/func/sub-01_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz'
     target = target.split('/')
-    result = layout_7t_trt.get_metadata(join(layout_7t_trt.root, *target),
-                                      include_entities=True)
+    result = layout_7t_trt.get_metadata(
+        join(layout_7t_trt.root, *target), include_entities=True)
     assert result['EchoTime'] == 0.020
     assert result['subject'] == '01'
     assert result['acquisition'] == 'fullbrain'
@@ -229,14 +230,17 @@ def test_get_val_none(layout_7t_trt, acq):
     t1w_files = layout_7t_trt.get(subject='01', ses='1', suffix='T1w')
     assert len(t1w_files) == 1
     assert 'acq' not in t1w_files[0].path
-    t1w_files = layout_7t_trt.get(subject='01', ses='1', suffix='T1w', acquisition=acq)
+    t1w_files = layout_7t_trt.get(
+        subject='01', ses='1', suffix='T1w', acquisition=acq)
     assert len(t1w_files) == 1
-    bold_files = layout_7t_trt.get(subject='01', ses='1', suffix='bold', acquisition=acq)
+    bold_files = layout_7t_trt.get(
+        subject='01', ses='1', suffix='bold', acquisition=acq)
     assert len(bold_files) == 0
 
 
 def test_get_val_enum_any(layout_7t_trt):
-    t1w_files = layout_7t_trt.get(subject='01', ses='1', suffix='T1w', acquisition=Query.ANY)
+    t1w_files = layout_7t_trt.get(
+        subject='01', ses='1', suffix='T1w', acquisition=Query.ANY)
     assert not t1w_files
     bold_files = layout_7t_trt.get(subject='01', ses='1', run=1, suffix='bold',
                                    acquisition=Query.ANY)
@@ -261,8 +265,8 @@ def test_ignore_files(layout_ds005):
     assert target1 not in layout1.files
     assert target2 not in layout1.files
     # now the models/ dir should show up, because passing ignore explicitly
-    # overrides the default - but 'model/extras/' should still be ignored because
-    # of the regex.
+    # overrides the default - but 'model/extras/' should still be ignored
+    # because of the regex.
     ignore = [re.compile('xtra'), 'dummy']
     layout2 = BIDSLayout(data_dir, validate=False, ignore=ignore)
     assert target1 in layout2.files
@@ -271,7 +275,7 @@ def test_ignore_files(layout_ds005):
 
 def test_force_index(layout_ds005):
     data_dir = join(get_test_data_path(), 'ds005')
-    target= join(data_dir, 'models', 'ds-005_type-test_model.json')
+    target = join(data_dir, 'models', 'ds-005_type-test_model.json')
     model_layout = BIDSLayout(data_dir, validate=True, force_index=['models'])
     assert target not in layout_ds005.files
     assert target in model_layout.files
@@ -287,7 +291,7 @@ def test_nested_include_exclude():
 
     # Nest a directory exclusion within an inclusion
     layout = BIDSLayout(data_dir, validate=True, force_index=['models'],
-                      ignore=[os.path.join('models', 'extras')])
+                        ignore=[os.path.join('models', 'extras')])
     assert layout.get_file(target1)
     assert not layout.get_file(target2)
 
@@ -300,7 +304,7 @@ def test_nested_include_exclude():
     # Force file inclusion despite directory-level exclusion
     models = ['models', target2]
     layout = BIDSLayout(data_dir, validate=True, force_index=models,
-                      ignore=[os.path.join('models', 'extras')])
+                        ignore=[os.path.join('models', 'extras')])
     assert layout.get_file(target1)
     assert layout.get_file(target2)
 
@@ -438,7 +442,8 @@ def test_parse_file_entities():
     target = {'subject': '03', 'session': '07', 'run': 4, 'suffix': 'sekret',
               'desc': 'bleargh', 'extension': 'nii.gz'}
     assert target == parse_file_entities(filename)
-    assert target == parse_file_entities(filename, config=['bids', 'derivatives'])
+    assert target == parse_file_entities(
+        filename, config=['bids', 'derivatives'])
 
     # Test with list of Entities
     entities = [
@@ -552,8 +557,9 @@ def test_indexed_file_associations(layout_7t_trt):
     targets = [
         os.path.join(layout_7t_trt.root,
                      'sub-01/ses-1/fmap/sub-01_ses-1_run-1_phasediff.nii.gz'),
-        os.path.join(img.dirname,
-                     'sub-01_ses-1_task-rest_acq-fullbrain_run-1_physio.tsv.gz'),
+        os.path.join(
+            img.dirname,
+            'sub-01_ses-1_task-rest_acq-fullbrain_run-1_physio.tsv.gz'),
         os.path.join(layout_7t_trt.root, 'task-rest_acq-fullbrain_bold.json')
     ]
     assert set([a.path for a in assocs]) == set(targets)

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -559,14 +559,14 @@ def test_indexed_file_associations(layout_7t_trt):
 
 
 def test_layout_save(layout_7t_trt):
-    _, f = tempfile.mkstemp(suffix='.db')
-    layout_7t_trt.save(f, replace_connection=False)
+    fdir = tempfile.mkdtemp()
+    layout_7t_trt.save(os.path.join(fdir, "f.sqlite"),
+                       replace_connection=False)
     data_dir = join(get_test_data_path(), '7t_trt')
-    layout = BIDSLayout(data_dir, database_file=f)
+    layout = BIDSLayout(data_dir, database_dir=fdir)
     oldfies = set(layout_7t_trt.get(suffix='events', return_type='file'))
     newfies = set(layout.get(suffix='events', return_type='file'))
     assert oldfies == newfies
-    os.unlink(f)
 
 
 def test_indexing_tag_conflict():

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -576,7 +576,7 @@ def test_layout_save(layout_7t_trt):
     layout_7t_trt.save(os.path.join(fdir, "f.sqlite"),
                        replace_connection=False)
     data_dir = join(get_test_data_path(), '7t_trt')
-    layout = BIDSLayout(data_dir, database_dir=fdir)
+    layout = BIDSLayout(data_dir, database_path=fdir)
     oldfies = set(layout_7t_trt.get(suffix='events', return_type='file'))
     newfies = set(layout.get(suffix='events', return_type='file'))
     assert oldfies == newfies


### PR DESCRIPTION
Closes #538 

Saves db files and initialization arguments (as JSON) into a folder. Each derivative gets its own folder within the main folder. 

This also checks to see that initialization arguments match the ones in the JSON file, when loading from disk. If they don't match, it throws an error. 

It could be argued that instead it should just warn you that arguments will be ignore, but I prefer to throw an error so that users think about what arguments they're passing, and how that may affect indexing. If they need to reindex, they can