### PR TITLE
ENH: Transformation-related improvements

### DIFF
--- a/bids/analysis/tests/test_transformations.py
+++ b/bids/analysis/tests/test_transformations.py
@@ -456,8 +456,14 @@ def test_dropna(sparse_run_variable_with_missing_values):
 
 
 def test_group(collection):
-    transform.Group(collection, ['gain', 'loss', 'parametric gain'],
-                    name='outcome_vars')
-    assert collection.groups == {
-        'outcome_vars': ['gain', 'loss', 'parametric gain']
-    }
+    coll = collection.clone()
+    transform.Group(coll, ['gain', 'loss'], name='outcome_vars')
+    assert coll.groups == { 'outcome_vars': ['gain', 'loss'] }
+
+    # Checks that variable groups are replaced properly
+    transform.Rename(coll, ['outcome_vars'],
+                     output=['gain_renamed', 'loss_renamed'])
+    assert 'gain_renamed' in coll.variables
+    assert 'loss_renamed' in coll.variables
+    assert 'gain' not in coll.variables
+    assert 'loss' not in coll.variables

--- a/bids/analysis/tests/test_transformations.py
+++ b/bids/analysis/tests/test_transformations.py
@@ -457,6 +457,10 @@ def test_dropna(sparse_run_variable_with_missing_values):
 
 def test_group(collection):
     coll = collection.clone()
+    with pytest.raises(ValueError):
+        # Can't use an existing variable name as the group name
+        transform.Group(coll, ['gain', 'loss'], name='gain')
+
     transform.Group(coll, ['gain', 'loss'], name='outcome_vars')
     assert coll.groups == { 'outcome_vars': ['gain', 'loss'] }
 

--- a/bids/analysis/tests/test_transformations.py
+++ b/bids/analysis/tests/test_transformations.py
@@ -453,3 +453,11 @@ def test_dropna(sparse_run_variable_with_missing_values):
     assert np.array_equal(post_trans.onset, [2, 5, 17])
     assert np.array_equal(post_trans.duration, [1.2, 1.6, 2])
     assert len(post_trans.index) == 3
+
+
+def test_group(collection):
+    transform.Group(collection, ['gain', 'loss', 'parametric gain'],
+                    name='outcome_vars')
+    assert collection.groups == {
+        'outcome_vars': ['gain', 'loss', 'parametric gain']
+    }

--- a/bids/analysis/tests/test_transformations.py
+++ b/bids/analysis/tests/test_transformations.py
@@ -301,13 +301,12 @@ def test_copy(collection):
                           collection['RT_copy'].values.values)
 
 
-def test_regex_variable_expansion(collection):
+def test_expand_variable_names(collection):
     # Should fail because two output values are required following expansion
     with pytest.raises(Exception):
-        transform.Copy(collection, 'resp', regex_variables='variables')
+        transform.Copy(collection, '*resp*')
 
-    transform.Copy(collection, 'resp', output_suffix='_copy',
-                   regex_variables='variables')
+    transform.Copy(collection, '*resp*', output_suffix='_copy')
     assert 'respnum_copy' in collection.variables.keys()
     assert 'respcat_copy' in collection.variables.keys()
     assert np.array_equal(collection['respcat'].values.values,

--- a/bids/analysis/transformations/__init__.py
+++ b/bids/analysis/transformations/__init__.py
@@ -1,7 +1,7 @@
 from .compute import (Sum, Product, Scale, Orthogonalize, Threshold, And, Or,
                       Not, Demean, Convolve)
 from .munge import (Split, Rename, Assign, Copy, Factor, Filter, Select,
-                    Delete, DropNA, Replace, ToDense)
+                    Delete, DropNA, Replace, ToDense, Group)
 
 __all__ = [
     'And',
@@ -13,6 +13,7 @@ __all__ = [
     'DropNA',
     'Factor',
     'Filter',
+    'Group',
     'Not',
     'Or',
     'Orthogonalize',

--- a/bids/analysis/transformations/base.py
+++ b/bids/analysis/transformations/base.py
@@ -182,19 +182,9 @@ class Transformation(metaclass=ABCMeta):
                 sr = self.collection.sampling_rate
                 self._variables[v] = var.to_dense(sr)
 
-    def _regex_replace_variables(self, args):
-        """For each argument named in args, interpret the values set in the
-        argument as regex patterns to potentially be replaced with variables
-        that match the pattern. """
-
-        args = listify(args)
-
-        if 'variables' in args:
-            args.remove('variables')
-            variables = True
-        else:
-            variables = False
-
+    def _match_variables(self):
+        """Filter all available arguments against collection's variables using
+        unix-style pattern matching."""
         # Ensure all keyword arguments user wants to scan are valid
         missing = set(args) - set(self.kwargs.keys())
         if missing:

--- a/bids/analysis/transformations/base.py
+++ b/bids/analysis/transformations/base.py
@@ -1,13 +1,16 @@
 """Base Transformation class and associated utilities. """
 
-import numpy as np
-import pandas as pd
-from bids.utils import listify
+import re
 import warnings
 from abc import ABCMeta, abstractmethod
 from copy import deepcopy
 import itertools
 import inspect
+
+import numpy as np
+import pandas as pd
+
+from bids.utils import listify
 from bids.variables import SparseRunVariable
 
 
@@ -107,21 +110,43 @@ class Transformation(metaclass=ABCMeta):
 
         self.kwargs = kwargs
 
-        # Replace variable groups with full variable lists
-        self._replace_variable_groups()
+        # Expand any detected variable group names or wild cards
+        self._expand_variable_groups()
+        self._expand_variable_names()
 
-        # Expand regex variable names
-        replace_args = self.kwargs.pop('regex_variables', None)
-        if replace_args is not None:
-            self._regex_replace_variables(replace_args)
-
-    def _replace_variable_groups(self):
+    def _expand_variable_groups(self):
         """ Replace any detected variable groups with the associated lists of
         variable names.
         """
         groups = self.collection.groups
         variables = [groups[v] if v in groups else [v] for v in self.variables]
         self.variables = list(itertools.chain(*variables))
+
+    def _expand_variable_names(self):
+        """Filter all available arguments against collection's variables using
+        unix-style pattern matching."""
+        def _replace_arg_values(values):
+            is_iter = isinstance(values, (list, tuple))
+            values = listify(values)
+            result = []
+            # Only try to match strings containing a relevant special character
+            for v in values:
+                if isinstance(v, str) and re.search('[\*\?\[\]]', v):
+                    result.append(self.collection.match_variables(v))
+                else:
+                    result.append([v])
+
+            result = list(itertools.chain(*result))
+            # Don't return a list unless we have to
+            if is_iter or len(result) > 1:
+                return result
+            return result[0]
+
+        # 'variables' is stored separately, so handle it separately
+        self.variables = _replace_arg_values(self.variables)
+
+        for k, arg in self.kwargs.items():
+            self.kwargs[k] = _replace_arg_values(arg)
 
     def _clone_variables(self):
         """Deep copy all variables the transformation touches. This prevents us
@@ -181,29 +206,6 @@ class Transformation(metaclass=ABCMeta):
             if isinstance(var, SparseRunVariable):
                 sr = self.collection.sampling_rate
                 self._variables[v] = var.to_dense(sr)
-
-    def _match_variables(self):
-        """Filter all available arguments against collection's variables using
-        unix-style pattern matching."""
-        # Ensure all keyword arguments user wants to scan are valid
-        missing = set(args) - set(self.kwargs.keys())
-        if missing:
-            raise ValueError("Arguments '%s' specified for regex-based "
-                             "variable name replacement, but were not found "
-                             "among keyword arguments." % missing)
-
-        def _replace_arg_values(names):
-            variables = listify(names)
-            variables = [self.collection.match_variables(c) for c in names]
-            variables = itertools.chain(*variables)
-            return list(set(variables))
-
-        # 'variables' is stored separately, so handle it separately
-        if variables:
-            self.variables = _replace_arg_values(self.variables)
-
-        for arg in args:
-            self.kwargs[arg] = _replace_arg_values(self.kwargs[arg])
 
     def transform(self):
 

--- a/bids/analysis/transformations/base.py
+++ b/bids/analysis/transformations/base.py
@@ -10,6 +10,7 @@ import itertools
 import inspect
 from bids.variables import SparseRunVariable
 
+
 class Transformation(metaclass=ABCMeta):
 
     ### Class-level settings ###
@@ -106,10 +107,21 @@ class Transformation(metaclass=ABCMeta):
 
         self.kwargs = kwargs
 
+        # Replace variable groups with full variable lists
+        self._replace_variable_groups()
+
         # Expand regex variable names
         replace_args = self.kwargs.pop('regex_variables', None)
         if replace_args is not None:
             self._regex_replace_variables(replace_args)
+
+    def _replace_variable_groups(self):
+        """ Replace any detected variable groups with the associated lists of
+        variable names.
+        """
+        groups = self.collection.groups
+        variables = [groups[v] if v in groups else [v] for v in self.variables]
+        self.variables = list(itertools.chain(*variables))
 
     def _clone_variables(self):
         """Deep copy all variables the transformation touches. This prevents us

--- a/bids/analysis/transformations/compute.py
+++ b/bids/analysis/transformations/compute.py
@@ -168,7 +168,7 @@ class Sum(Transformation):
             if len(weights.ravel()) != data.shape[1]:
                 raise ValueError("If weights are passed to sum(), the number "
                                  "of elements must equal number of variables"
-                                 "being summed.")
+                                 " being summed.")
         return (data * weights).sum(axis=1)
 
 

--- a/bids/analysis/transformations/munge.py
+++ b/bids/analysis/transformations/munge.py
@@ -206,6 +206,18 @@ class Filter(Transformation):
         return var
 
 
+class Group(Transformation):
+    """Groups a list of variables."""
+
+    _groupable = False
+    _loopable = False
+    _input_type = 'variable'
+    _return_type = 'none'
+
+    def _transform(self, variables, name):
+        self.collection.groups[name] = [v.name for v in variables]
+
+
 class Rename(Transformation):
     """Rename a variable.
 

--- a/bids/analysis/transformations/munge.py
+++ b/bids/analysis/transformations/munge.py
@@ -215,6 +215,9 @@ class Group(Transformation):
     _return_type = 'none'
 
     def _transform(self, variables, name):
+        if name in self.variables:
+            raise ValueError("Variable group name '{}' conflicts with an "
+                             "existing variable name!".format(name))
         self.collection.groups[name] = [v.name for v in variables]
 
 

--- a/bids/analysis/transformations/munge.py
+++ b/bids/analysis/transformations/munge.py
@@ -283,8 +283,8 @@ class Select(Transformation):
 
 
 class Split(Transformation):
-    """Split a single variable into N variables as defined by the levels of one or
-    more other variables.
+    """Split a single variable into N variables as defined by the levels of one
+    or more other variables.
 
     Parameters
     ----------
@@ -299,7 +299,7 @@ class Split(Transformation):
     _allow_categorical = ('by',)
     _densify = ('variables', 'by')
 
-    def _transform(self, var, by, drop_orig=True):
+    def _transform(self, var, by):
 
         if not isinstance(var, SimpleVariable):
             self._densify_variables()
@@ -314,29 +314,13 @@ class Split(Transformation):
         group_data = pd.concat(by_variables, axis=1, sort=True)
         group_data.columns = listify(by)
 
-        # For sparse data, we need to set up a 1D grouper
-        if isinstance(var, SimpleVariable):
-            # Create single grouping variable by combining all 'by' variables
-            if group_data.shape[1] == 1:
-                group_labels = group_data.iloc[:, 0].values
-            else:
-                group_rows = group_data.astype(str).values.tolist()
-                group_labels = ['_'.join(r) for r in group_rows]
+        # Use patsy to create splitting design matrix
+        group_data = group_data.astype(str)
+        formula = '0+' + ':'.join(listify(by))
+        dm = dmatrix(formula, data=group_data, return_type='dataframe')
+        dm.columns = [col.replace(':', '.') for col in dm.columns]
 
-            result = var.split(group_labels)
-
-        # For dense data, use patsy to create design matrix, then multiply
-        # it by target variable
-        else:
-            group_data = group_data.astype(str)
-            formula = '0+' + '*'.join(listify(by))
-            dm = dmatrix(formula, data=group_data, return_type='dataframe')
-            result = var.split(dm)
-
-        if drop_orig:
-            self.collection.variables.pop(var.name)
-
-        return result
+        return var.split(dm)
 
 
 class ToDense(Transformation):

--- a/bids/variables/kollekshuns.py
+++ b/bids/variables/kollekshuns.py
@@ -67,6 +67,10 @@ class BIDSVariableCollection(object):
         self.variables = {v.name: v for v in variables}
         self._index_entities()
 
+        # Container for variable groups (see BIDS-StatsModels spec)--maps from
+        # group names to lists of variables.
+        self.groups = {}
+
     @staticmethod
     def merge_variables(variables, **kwargs):
         """Concatenates Variables along row axis.

--- a/bids/variables/kollekshuns.py
+++ b/bids/variables/kollekshuns.py
@@ -5,17 +5,20 @@ module of the same name on Python 2. We could go with something sensible but
 verbose like 'variable_collections', but that would make far too much sense.
 """
 
-import pandas as pd
 from copy import copy
-from pandas.api.types import is_numeric_dtype
 import warnings
 import re
-from .variables import (SparseRunVariable, SimpleVariable, DenseRunVariable,
-                        merge_variables, BIDSVariable)
 from collections import OrderedDict
 from itertools import chain
-from bids.utils import listify, matches_entities
+import fnmatch
+
 import numpy as np
+import pandas as pd
+from pandas.api.types import is_numeric_dtype
+
+from .variables import (SparseRunVariable, SimpleVariable, DenseRunVariable,
+                        merge_variables, BIDSVariable)
+from bids.utils import listify, matches_entities
 
 
 class BIDSVariableCollection(object):
@@ -218,8 +221,8 @@ class BIDSVariableCollection(object):
             obj.name = var
         self.variables[var] = obj
 
-    def match_variables(self, pattern, return_type='name'):
-        """Return columns whose names match the provided regex pattern.
+    def match_variables(self, pattern, return_type='name', match_type='unix'):
+        """Return columns whose names match the provided pattern.
 
         Parameters
         ----------
@@ -230,11 +233,19 @@ class BIDSVariableCollection(object):
             'name': Returns a list of names of matching variables.
             'variable': Returns a list of Variable objects whose names
             match.
+        match_type : str
+            Matching approach to use. Either 'regex' (full-blown regular
+                expression matching) or 'unix' (unix-style pattern matching
+                via the fnmatch module).
         """
-        pattern = re.compile(pattern)
-        vars_ = [v for v in self.variables.values() if pattern.search(v.name)]
-        return vars_ if return_type.startswith('var') \
-            else [v.name for v in vars_]
+        if match_type.lower().startswith('re'):
+            pattern = re.compile(pattern)
+            vars_ = [v for v in self.variables.keys() if pattern.search(v)]
+        else:
+            vars_ = fnmatch.filter(list(self.variables.keys()), pattern)
+
+        return vars_ if return_type == 'name' \
+            else [self.variables[v] for v in vars_]
 
 
 class BIDSRunVariableCollection(BIDSVariableCollection):

--- a/bids/variables/tests/test_collections.py
+++ b/bids/variables/tests/test_collections.py
@@ -2,7 +2,8 @@ from bids.layout import BIDSLayout
 import pytest
 from os.path import join, dirname, abspath
 from bids.tests import get_test_data_path
-from bids.variables import DenseRunVariable, merge_collections
+from bids.variables import (DenseRunVariable, SparseRunVariable,
+                            merge_collections)
 
 
 @pytest.fixture(scope="module")
@@ -104,3 +105,15 @@ def test_get_collection_entities(run_coll_list):
     ents = merged.entities
     assert {'task', 'subject', 'suffix', 'datatype'} == set(ents.keys())
     assert ents['subject'] == '02'
+
+
+def test_match_variables(run_coll):
+    matches = run_coll.match_variables('^.{1,2}a', match_type='regex')
+    assert set(matches) == {'gain', 'parametric gain'}
+    assert not run_coll.match_variables('.{1,3}a')
+    matches = run_coll.match_variables('^.{1,2}a', match_type='regex',
+                                       return_type='variable')
+    assert len(matches) == 2
+    assert all([isinstance(m, SparseRunVariable) for m in matches])
+    matches = run_coll.match_variables('*gain')
+    assert set(matches) == {'gain', 'parametric gain'}

--- a/bids/variables/variables.py
+++ b/bids/variables/variables.py
@@ -279,22 +279,24 @@ class SimpleVariable(BIDSVariable):
 
         Parameters
         ----------
-        grouper : iterable
-            list to groupby, where each unique value will
-            be taken as the name of the resulting column.
+        grouper : :obj:`pandas.DataFrame`
+            Binary DF specifying the design matrix to use for splitting. Number
+            of rows must match current ``SparseRunVariable``;
+            a new ``SparseRunVariable`` will be generated for each column in
+            the grouper.
 
         Returns
         -------
-        A list of SparseRunVariables, one per unique value in the
-        grouper.
+        A list of SparseRunVariables, one per column in the grouper DF.
         """
         data = self.to_df(condition=True, entities=True)
         data = data.drop('condition', axis=1)
 
         subsets = []
-        for i, (name, g) in enumerate(data.groupby(grouper)):
-            name = '%s.%s' % (self.name, name)
-            col = self.__class__(name=name, data=g, source=self.source,
+        for i, col_name in enumerate(grouper.columns):
+            col_data = data.loc[grouper[col_name], :]
+            name = '{}.{}'.format(self.name, col_name)
+            col = self.__class__(name=name, data=col_data, source=self.source,
                                  run_info=getattr(self, 'run_info', None))
             subsets.append(col)
         return subsets


### PR DESCRIPTION
This PR implements a number of improvements, mostly focused on transformation handling:

* Implement supports for variable groups (essentially just aliases to multiple variables), as documented in the BIDS-StatsModel spec.
* Adds the `Group` transformation, per the spec, which enables explicit creation of variable groups.
* Improves/cleans up the `Split` transformation and updates the returned variable names to reflect the spec
* Generalizes the `Collection.match_variables()` method to allow unix-style pattern matching.
* Implements transformation argument wild-card expansion (closes #487).