### PR TITLE
Helpful error for db argument mismatch, and add classmethod load_from_db

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -233,12 +233,12 @@ class BIDSLayout(object):
             ignore = self._default_ignore
 
         # Instantiate after root validation to ensure os.path.join works
-        ignore = [os.path.abspath(os.path.join(self.root, patt))
-                  if isinstance(patt, str) else patt
-                  for patt in listify(ignore or [])]
-        force_index = [os.path.abspath(os.path.join(self.root, patt))
+        self.ignore = [os.path.abspath(os.path.join(self.root, patt))
                        if isinstance(patt, str) else patt
-                       for patt in listify(force_index or [])]
+                       for patt in listify(ignore or [])]
+        self.force_index = [os.path.abspath(os.path.join(self.root, patt))
+                            if isinstance(patt, str) else patt
+                            for patt in listify(force_index or [])]
 
         # Initialize the BIDS validator and examine ignore/force_index args
         self._validate_force_index()

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -409,10 +409,11 @@ class BIDSLayout(object):
             for k, v in saved_args.items():
                 if self._init_args[k] != v:
                     raise ValueError(
-                        f"Initialization argument ({k!r}) directories "
-                        f" not match fordatabase_path: {database_path}.\n"
-                        f"Saved value: {v}. \n"
-                        f"Current value: {self._init_args[k]}"
+                        "Initialization argument ('{}') does not match "
+                        "for database_path: {}.\n"
+                        "Saved value: {}.\n"
+                        "Current value: {}.".format(
+                            k, database_path, v, self._init_args[k])
                         )
         else:
             engine = self.session.get_bind()

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -219,6 +219,8 @@ class BIDSLayout(object):
 
         self.session = None
 
+        index_dataset = self._init_db(database_path, reset_database)
+
         # Do basic BIDS validation on root directory
         self._validate_root()
 
@@ -235,8 +237,6 @@ class BIDSLayout(object):
 
         # Initialize the BIDS validator and examine ignore/force_index args
         self._validate_force_index()
-
-        index_dataset = self._init_db(database_path, reset_database)
 
         if index_dataset:
             # Create Config objects

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -542,7 +542,8 @@ class BIDSLayout(object):
         # To load from a database, set initalization parameters to those
         # found in database_path JSON
         database_file, database_sidecar = cls._make_db_paths(database_path)
-        init_args = json.load(database_sidecar.open())
+        with database_sidecar.open() as fobj:
+            init_args = json.load(fobj)
 
         return cls(database_path=database_path, **init_args)
 

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -542,8 +542,7 @@ class BIDSLayout(object):
         # To load from a database, set initalization parameters to those
         # found in database_path JSON
         database_file, database_sidecar = cls._make_db_paths(database_path)
-        with database_sidecar.open() as fobj:
-            init_args = json.load(fobj)
+        init_args = json.loads(database_sidecar.read_text())
 
         return cls(database_path=database_path, **init_args)
 
@@ -584,8 +583,7 @@ class BIDSLayout(object):
             self._set_session(str(database_file))
 
         # Dump instance arguments to JSON
-        with database_sidecar.open('w') as fobj:
-            json.dump(self.init_args, fobj)
+        database_sidecar.write_text(json.dumps(self.init_args))
 
         # Recursively save children
         for pipeline_name, der in self.derivatives.items():

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -394,9 +394,9 @@ class BIDSLayout(object):
             for k, v in saved_args.items():
                 if instance_args[k] != v:
                     raise ValueError(
-                        f"Initialization argument ({k}) do not match for "
-                        f"database_path: {database_path}. Saved value: f{v}."
-                        f"Current value: f{instance_args[k]}"
+                        f"Initialization argument (\"{k}\") do not match for "
+                        f"database_path: {database_path}.\nSaved value: f{v}."
+                        f"\nCurrent value: f{instance_args[k]}"
                         )
         else:
             engine = self.session.get_bind()

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -206,6 +206,8 @@ class BIDSLayout(object):
         self.sources = sources
         self.regex_search = regex_search
         self.config_filename = config_filename
+        self.ignore = ignore
+        self.force_index = force_index
 
         if database_file is not None:
             database_path = database_file
@@ -224,16 +226,16 @@ class BIDSLayout(object):
         # Do basic BIDS validation on root directory
         self._validate_root()
 
-        if ignore is None:
-            ignore = self._default_ignore
+        if self.ignore is None:
+            self.ignore = self._default_ignore
 
         # Instantiate after root validation to ensure os.path.join works
         self.ignore = [os.path.abspath(os.path.join(self.root, patt))
                        if isinstance(patt, str) else patt
-                       for patt in listify(ignore or [])]
+                       for patt in listify(self.ignore or [])]
         self.force_index = [os.path.abspath(os.path.join(self.root, patt))
                             if isinstance(patt, str) else patt
-                            for patt in listify(force_index or [])]
+                            for patt in listify(self.force_index or [])]
 
         # Initialize the BIDS validator and examine ignore/force_index args
         self._validate_force_index()

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -394,8 +394,9 @@ class BIDSLayout(object):
             for k, v in saved_args.items():
                 if instance_args[k] != v:
                     raise ValueError(
-                        "Initialization arguments do not match for database_path:"
-                        " {}".format(database_path)
+                        f"Initialization argument ({k}) do not match for "
+                        f"database_path: {database_path}. Saved value: f{v}."
+                        f"Current value: f{instance_args[k]}"
                         )
         else:
             engine = self.session.get_bind()

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -372,7 +372,9 @@ class BIDSLayout(object):
             if a in self.__dict__
         }
         for k in ['ignore', 'force_index']:
-            instance_args[k] = [str(a) for a in self.__dict__[k]]
+            kv = self.__dict__[k]
+            if kv is not None:
+                instance_args[k] = [str(a) for a in kv if a is not None]
         return instance_args
 
     def _init_db(self, database_path=None, reset_database=False):

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -216,7 +216,7 @@ class BIDSLayout(object):
             database_path = database_file
             warnings.warn(
                 'In pybids 0.10 database_file argument was deprecated in favor'
-                ' of database_path, and will and will be removed in 0.12. '
+                ' of database_path, and will be removed in 0.12. '
                 'For now, treating database_file as a directory.',
                 DeprecationWarning)
         if database_path:

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -362,7 +362,7 @@ class BIDSLayout(object):
     def _make_db_paths(database_path):
         if database_path is not None:
             database_path = Path(database_path)
-            database_file = database_path / 'layout_index.sqlilte'
+            database_file = database_path / 'layout_index.sqlite'
             database_sidecar = database_path / 'layout_args.json'
             database_path.mkdir(exist_ok=True, parents=True)
         else:

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -404,8 +404,7 @@ class BIDSLayout(object):
         self._set_session(database_file)
 
         if not reset_database:
-            with open(database_sidecar) as fobj:
-                saved_args = json.load(fobj)
+            saved_args = json.loads(database_sidecar.read_text())
             for k, v in saved_args.items():
                 if self._init_args[k] != v:
                     raise ValueError(

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -420,7 +420,7 @@ class BIDSLayout(object):
             Base.metadata.drop_all(engine)
             Base.metadata.create_all(engine)
             if database_sidecar:
-                database_sidecar.write_text(json.dumps(self.init_args))
+                database_sidecar.write_text(json.dumps(self._init_args))
 
             return True
 

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -206,8 +206,6 @@ class BIDSLayout(object):
         self.sources = sources
         self.regex_search = regex_search
         self.config_filename = config_filename
-        self.ignore = ignore
-        self.force_index = force_index
         # Store init arguments for saving
         self._sanitize_init_args(
             root=root, validate=validate, absolute_paths=absolute_paths,
@@ -231,16 +229,16 @@ class BIDSLayout(object):
         # Do basic BIDS validation on root directory
         self._validate_root()
 
-        if self.ignore is None:
-            self.ignore = self._default_ignore
+        if ignore is None:
+            ignore = self._default_ignore
 
         # Instantiate after root validation to ensure os.path.join works
-        self.ignore = [os.path.abspath(os.path.join(self.root, patt))
+        ignore = [os.path.abspath(os.path.join(self.root, patt))
+                  if isinstance(patt, str) else patt
+                  for patt in listify(ignore or [])]
+        force_index = [os.path.abspath(os.path.join(self.root, patt))
                        if isinstance(patt, str) else patt
-                       for patt in listify(self.ignore or [])]
-        self.force_index = [os.path.abspath(os.path.join(self.root, patt))
-                            if isinstance(patt, str) else patt
-                            for patt in listify(self.force_index or [])]
+                       for patt in listify(force_index or [])]
 
         # Initialize the BIDS validator and examine ignore/force_index args
         self._validate_force_index()

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -407,7 +407,7 @@ class BIDSLayout(object):
             for k, v in saved_args.items():
                 if self.init_args[k] != v:
                     raise ValueError(
-                        f"Initialization argument (\"{k}\") directories "
+                        f"Initialization argument ({k!r}) directories "
                         f" not match fordatabase_path: {database_path}.\n"
                         f"Saved value: {v}. \n"
                         f"Current value: {self.init_args[k]}"

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -212,7 +212,7 @@ class BIDSLayout(object):
             derivatives=derivatives, ignore=ignore, force_index=force_index,
             index_metadata=index_metadata, config=config)
 
-        if database_file is not None:
+        if database_path is None and database_file is not None:
             database_path = database_file
             warnings.warn(
                 'In pybids 0.10 database_file argument was deprecated in favor'

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -397,8 +397,8 @@ class BIDSLayout(object):
         # to setting the session (which creates the empty database file)
         reset_database = (
             reset_database or  # Manual Request
-            not database_path or  # In memory transient db
-            not os.path.exists(database_file)  # New file based db created
+            not database_file or  # In memory transient db
+            not database_file.exists()  # New file based db created
         )
 
         self._set_session(database_file)

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -538,7 +538,7 @@ class BIDSLayout(object):
         return self.get_files()
 
     @classmethod
-    def load_from_db(cls, database_path):
+    def load(cls, database_path):
         # To load from a database, set initalization parameters to those
         # found in database_path JSON
         database_file, database_sidecar = cls._make_db_paths(database_path)

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -364,7 +364,7 @@ class BIDSLayout(object):
             database_path = Path(database_path)
             database_file = database_path / 'layout_index.sqlilte'
             database_sidecar = database_path / 'layout_args.json'
-            database_path.mkdir(exist_ok=True)
+            database_path.mkdir(exist_ok=True, parents=True)
         else:
             database_file = None
             database_sidecar = None

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -373,8 +373,9 @@ class BIDSLayout(object):
         }
         for k in ['ignore', 'force_index']:
             kv = self.__dict__[k]
-            if kv is not None:
-                instance_args[k] = [str(a) for a in kv if a is not None]
+            instance_args[k] = [
+                str(a) for a in kv if a is not None] if kv is not None else None
+
         return instance_args
 
     def _init_db(self, database_path=None, reset_database=False):

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -400,8 +400,8 @@ class BIDSLayout(object):
                 if instance_args[k] != v:
                     raise ValueError(
                         f"Initialization argument (\"{k}\") do not match for "
-                        f"database_path: {database_path}.\nSaved value: f{v}."
-                        f"\nCurrent value: f{instance_args[k]}"
+                        f"database_path: {database_path}.\nSaved value: {v}."
+                        f"\nCurrent value: {instance_args[k]}"
                         )
         else:
             engine = self.session.get_bind()

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -420,8 +420,7 @@ class BIDSLayout(object):
             Base.metadata.drop_all(engine)
             Base.metadata.create_all(engine)
             if database_sidecar:
-                with open(database_sidecar, 'w') as fobj:
-                    json.dump(self._init_args, fobj)
+                database_sidecar.write_text(json.dumps(self.init_args))
 
             return True
 

--- a/bids/layout/tests/conftest.py
+++ b/bids/layout/tests/conftest.py
@@ -67,3 +67,8 @@ def layout_synthetic(request, db_dir):
     database_path = str(db_dir / request.param) if request.param else None
     return BIDSLayout(path, derivatives=True,
                       database_path=database_path)
+
+@pytest.fixture(scope="module")
+def layout_synthetic_nodb(request, db_dir):
+    path = join(get_test_data_path(), 'synthetic')
+    return BIDSLayout(path, derivatives=True)

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -627,3 +627,11 @@ def test_get_with_regex_search_bad_dtype(layout_7t_trt):
                     regex_search=True)
     # Two runs (1 per session) for each of subjects '10' and '01'
     assert len(results) == 4
+
+def test_load_layout(layout_synthetic_nodb, db_dir):
+    db_path = str(db_dir / 'tmp_db')
+    layout_synthetic_nodb.save(db_path)
+    reloaded = BIDSLayout.load(db_path)
+    assert sorted(layout_synthetic_nodb.get(return_type='file')) == \
+        sorted(reloaded.get(return_type='file'))
+    assert layout_synthetic_nodb._init_args == reloaded._init_args


### PR DESCRIPTION
- A nicer error message if your db's init arguments mismatch the ones you ask for
- More importantly, a classmethod `load_from_db` that will load the `BIDSLayout` using the init arguments found in the `JSON`
- Finally, saves the actual untouched arguments passed into `BIDSLayout` to JSON. 