### PR TITLE
DOC: Remove Python 2 support statement, now that v0.10.0 has dropped it

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ PyBIDS is a Python library to centralize interactions with datasets conforming
 BIDS (Brain Imaging Data Structure) format.  For more information about BIDS
 visit http://bids.neuroimaging.io.
 
-PyBIDS currently supports Python 2 and 3 on POSIX operating systems (including Mac OS). We anticipate dropping Python 2 support in the near future, and Python 2 users are encouraged to switch to Python 3. Windows is not officially supported, though most PyBIDS functionality will probably work fine.
+PyBIDS currently supports Python 3 on POSIX operating systems (including Mac OS).  Windows is not officially supported, though most PyBIDS functionality will probably work fine.
 
 ## Installation
 PyBIDS is most easily installed from pip. To install the latest official release:


### PR DESCRIPTION
According to the [release notes for PyBIDS 0.10.0](https://github.com/bids-standard/pybids/releases/tag/0.10.0), it has now dropped Python 2 support. How about updating the README to reflect that?