### PR TITLE
Correct term "caret" to "angle bracket" in helpstrings

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -1406,7 +1406,7 @@ class BIDSLayout(object):
             surrounded by curly braces. Optional portions of the patterns
             should be denoted by square brackets. Entities that require a
             specific value for the pattern to match can pass them inside
-            carets. Default values can be assigned by specifying a string
+            angle brackets. Default values can be assigned by specifying a string
             after the pipe operator. E.g., (e.g., {type<image>|bold} would
             only match the pattern if the entity 'type' was passed and its
             value is "image", otherwise the default value "bold" will be

--- a/bids/layout/writing.py
+++ b/bids/layout/writing.py
@@ -74,7 +74,7 @@ def build_path(entities, path_patterns, strict=False):
         surrounded by curly braces. Optional portions of the patterns
         should be denoted by square brackets. Entities that require a
         specific value for the pattern to match can pass them inside
-        carets. Default values can be assigned by specifying a string after
+        angle brackets. Default values can be assigned by specifying a string after
         the pipe operator. E.g., (e.g., {type<image>|bold} would only match
         the pattern if the entity 'type' was passed and its value is
         "image", otherwise the default value "bold" will be used).


### PR DESCRIPTION
Just a helpstring fix.

These symbols - < > - are angle brackets, not "carets". Typographically, a [caret](https://en.wikipedia.org/wiki/Caret) is an upward pointing chevron or arrow thingy, like ^ or ‸.

