### PR TITLE
Fix "strict" helptext in BIDSLayout.write_contents_to_file

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -1537,6 +1537,7 @@ class BIDSLayout(object):
         strict : bool
             If True, all entities must be matched inside a
             pattern in order to be a valid match. If False, extra entities
+            will be ignored so long as all mandatory entities are found.
         validate : bool
             If True, built path must pass BIDS validator. If
             False, no validation is attempted, and an invalid path may be


### PR DESCRIPTION
Looks like a copy-paste error dropped a line in the helpstring for `BIDSLayout`'s `write_contents_to_file` method when it was copied from the above `build_path` method's helpstring. This PR fixes it.

Fixes  #563.