### PR TITLE
Upscale to collection sampling rate prior to resampling

### DIFF
--- a/bids/variables/kollekshuns.py
+++ b/bids/variables/kollekshuns.py
@@ -319,7 +319,7 @@ class BIDSRunVariableCollection(BIDSVariableCollection):
                 continue
             if isinstance(var, SparseRunVariable):
                 if force_dense and is_numeric_dtype(var.values):
-                    var = var.to_dense(self.sampling_rate)
+                    var = var.to_dense()
                     _variables[name] = var
                 else:
                     continue

--- a/bids/variables/kollekshuns.py
+++ b/bids/variables/kollekshuns.py
@@ -319,14 +319,16 @@ class BIDSRunVariableCollection(BIDSVariableCollection):
                 continue
             if isinstance(var, SparseRunVariable):
                 if force_dense and is_numeric_dtype(var.values):
-                    _variables[name] = var.to_dense(sampling_rate)
-            else:
-                # None if in_place; no update needed
-                _var = var.resample(sampling_rate,
-                                    inplace=in_place,
-                                    kind=kind)
-                if not in_place:
-                    _variables[name] = _var
+                    var = var.to_dense(self.sampling_rate)
+                    if self.sampling_rate == sampling_rate:
+                        _variables[name] = var
+                        continue
+
+            _var = var.resample(sampling_rate,
+                                inplace=in_place,
+                                kind=kind)
+            if not in_place:
+                _variables[name] = _var
 
         if in_place:
             for k, v in _variables.items():

--- a/bids/variables/kollekshuns.py
+++ b/bids/variables/kollekshuns.py
@@ -323,6 +323,8 @@ class BIDSRunVariableCollection(BIDSVariableCollection):
                     if self.sampling_rate == sampling_rate:
                         _variables[name] = var
                         continue
+                else:
+                    continue
 
             _var = var.resample(sampling_rate,
                                 inplace=in_place,

--- a/bids/variables/kollekshuns.py
+++ b/bids/variables/kollekshuns.py
@@ -320,19 +320,17 @@ class BIDSRunVariableCollection(BIDSVariableCollection):
             if isinstance(var, SparseRunVariable):
                 if force_dense and is_numeric_dtype(var.values):
                     var = var.to_dense(self.sampling_rate)
-                    if self.sampling_rate == sampling_rate:
-                        _variables[name] = var
-                        continue
+                    _variables[name] = var
                 else:
                     continue
 
             _var = var.resample(sampling_rate,
                                 inplace=in_place,
                                 kind=kind)
-            if not in_place:
+            if not in_place:  # None if in_place; no update needed
                 _variables[name] = _var
 
-        if in_place:
+        if in_place:  # Replace densified variables
             for k, v in _variables.items():
                 self.variables[k] = v
             self.sampling_rate = sampling_rate


### PR DESCRIPTION
Fixes #361 

The issue is that when you call `to_df` on `BIDSRunVariableCollection`, the `resample` method will call `to_dense` on any `SparseRunVariable`. 

The problem with that is that calling `to_dense` only takes samples at the output `sampling_rate`. If that sampling rate is low (such as "TR" in `get_design_matrix`), it will simply ignore any values that don't coincide with the TR. 

Instead, now it will upscale with `to_dense` to the sampling_rate of the collection (10hz by default), and then resample to the TR. 