### PR TITLE
FIX: Domain entity, and slow __repr__

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -300,11 +300,25 @@ class BIDSLayout(object):
     def __repr__(self):
         """Provide a tidy summary of key properties."""
         # TODO: Replace each nested list comprehension with a single DB query
-        n_sessions = len([session for isub in self.get_subjects()
-                          for session in self.get_sessions(subject=isub)])
-        n_runs = len([run for isub in self.get_subjects()
-                      for run in self.get_runs(subject=isub)])
-        n_subjects = len(self.get_subjects())
+        subjects = [s.value for s in self.session.query(Tag).filter_by(
+                entity_name='subject').group_by(Tag._value)]
+
+        n_subjects = len(subjects)
+
+        n_sessions = len(
+            set(
+                [(t.value, t.file.entities.get('subject'))
+                 for t in
+                 self.session.query(Tag).filter_by(entity_name='session')])
+            )
+
+        n_runs = len(
+            set(
+                [(t.value, t.file.entities.get('subject'))
+                 for t in
+                 self.session.query(Tag).filter_by(entity_name='run')])
+            )
+
         root = self.root[-30:]
         s = ("BIDS Layout: ...{} | Subjects: {} | Sessions: {} | "
              "Runs: {}".format(root, n_subjects, n_sessions, n_runs))

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -487,7 +487,7 @@ class BIDSLayout(object):
         # We assume something is a BIDS-derivatives dataset if it either has a
         # defined pipeline name, or is applying the 'derivatives' rules.
         pl_name = self.description.get("PipelineDescription", {}).get("Name")
-        is_deriv = bool(pl_name or ('derivatives' in self.config))
+        is_deriv = bool('derivatives' in self.config)
 
         return ((not is_deriv and 'raw' in scope) or
                 (is_deriv and ('derivatives' in scope or pl_name in scope)))

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -307,20 +307,20 @@ class BIDSLayout(object):
 
         n_sessions = len(
             set(
-                [(t.value, t.file.entities.get('subject'))
+                (t.value, t.file.entities.get('subject'))
                  for t in
                  self.session.query(Tag).filter_by(entity_name='session')
                  if t.file.entities.get('subject')
-                 ])
+                 )
             )
 
         n_runs = len(
             set(
-                [(t.value, t.file.entities.get('subject'))
+                (t.value, t.file.entities.get('subject'))
                  for t in
                  self.session.query(Tag).filter_by(entity_name='run')
                  if t.file.entities.get('subject')
-                 ])
+                 )
             )
 
         root = self.root[-30:]

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -309,14 +309,18 @@ class BIDSLayout(object):
             set(
                 [(t.value, t.file.entities.get('subject'))
                  for t in
-                 self.session.query(Tag).filter_by(entity_name='session')])
+                 self.session.query(Tag).filter_by(entity_name='session')
+                 if t.file.entities.get('subject')
+                 ])
             )
 
         n_runs = len(
             set(
                 [(t.value, t.file.entities.get('subject'))
                  for t in
-                 self.session.query(Tag).filter_by(entity_name='run')])
+                 self.session.query(Tag).filter_by(entity_name='run')
+                 if t.file.entities.get('subject')
+                 ])
             )
 
         root = self.root[-30:]

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -299,11 +299,11 @@ class BIDSLayout(object):
 
     def __repr__(self):
         """Provide a tidy summary of key properties."""
-        # TODO: Replace each nested list comprehension with a single DB query
-        subjects = [s.value for s in self.session.query(Tag).filter_by(
-                entity_name='subject').group_by(Tag._value)]
-
-        n_subjects = len(subjects)
+        n_subjects = len(
+            [s.value
+             for s in self.session.query(Tag).filter_by(
+                 entity_name='subject').group_by(Tag._value)]
+            )
 
         n_sessions = len(
             set(


### PR DESCRIPTION
Fixes #557 and #555 

- Uses only the presence of 'derivatives' in config to determine if a `BIDSLayout` is in the `derivative` domain. I could see an argument that we should consider all which have more than only the core `bids` config listed.

- I used some very inelegant (rather janky) counts using just the `Tag` model as Tal suggested. 
%timeit results using the `synthetic` test dataset:

Previous method: 606ms
This PR: 4.99ms
Only counting distinct session id's, not nested within subjects: 3.99ms (so not worth only doing this)

I will say that just doing `layout.get_subjects` takes 35ms on this dataset, so there's room for optimization on `.get`. 

On a real dataset with no sessions (life), I saw a 10x speedup: 2.83s vs 0.27s
