### PR TITLE
Replace os.path.sep with fwdslash because bids validator hardcodes fwd

### DIFF
--- a/bids/layout/index.py
+++ b/bids/layout/index.py
@@ -80,7 +80,7 @@ class BIDSLayoutIndexer(object):
         # BIDS validator expects absolute paths, but really these are relative
         # to the BIDS project root.
         to_check = os.path.relpath(f, self.root)
-        to_check = os.path.join(os.path.sep, to_check)
+        to_check = os.path.join('/', to_check)
         return self.validator.is_bids(to_check)
 
     def _index_dir(self, path, config, default_action=None):


### PR DESCRIPTION
bids_validator uses regexp that hardcodes `/`, but on Windows `os.path.sep` returns `\\`, so the comparison always fails.

There may be other locations where `os.path.sep` is used which is also problematic, but this was this first one I encountered and at least allowed me to validate my top-level files.