### PR TITLE
Add Replace as exception to recursive JSON conversion

### DIFF
--- a/bids/utils.py
+++ b/bids/utils.py
@@ -44,9 +44,10 @@ def natural_sort(l, field=None):
 
 def convert_JSON(j):
     """ Recursively convert CamelCase keys to snake_case.
-    From: https://stackoverflow.com/questions/17156078/converting-identifier-naming-between-camelcase-and-underscores-during-json-seria
+    From: https://stackoverflow.com/questions/17156078/
+    converting-identifier-naming-between-camelcase-and-
+    underscores-during-json-seria
     """
-
     def camel_to_snake(s):
         a = re.compile('((?<=[a-z0-9])[A-Z]|(?!^)[A-Z](?=[a-z]))')
         return a.sub(r'_\1', s).lower()
@@ -54,7 +55,7 @@ def convert_JSON(j):
     def convertArray(a):
         newArr = []
         for i in a:
-            if isinstance(i,list):
+            if isinstance(i, list):
                 newArr.append(convertArray(i))
             elif isinstance(i, dict):
                 newArr.append(convert_JSON(i))
@@ -66,7 +67,8 @@ def convert_JSON(j):
     for k, value in j.items():
         newK = camel_to_snake(k)
 
-        if isinstance(value, dict):
+        # Replace transformation uses a dict, so skip lower-casing
+        if isinstance(value, dict) and k != 'Replace':
             out[newK] = convert_JSON(value)
         elif isinstance(value, list):
             out[newK] = convertArray(value)


### PR DESCRIPTION
- Closes #588 

Values to be replaced were being modified to lower case by `convert_JSON`. Fixes this by adding an exception if parent key == `Replace`.

I looked at the spec, and looks like this is the only transformation argument that is a dict, so there shouldn't be other cases of this issue. 

