### PR TITLE
CI: Test on Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: xenial
 language: python
 cache: pip
 
-# python and global.matrix are crossed to create the base build matrix
+# python and env.jobs are crossed to create the base build matrix
 python:
   - 3.5
   - 3.6
@@ -16,12 +16,12 @@ env:
     - EXTRA_WHEELS="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
     - PRE_WHEELS="https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com"
     - CHECK_TYPE="travis_tests"
-  matrix:
+  jobs:
     - EXTRA_PIP_FLAGS="--find-links=$EXTRA_WHEELS"
     - EXTRA_PIP_FLAGS="--pre --find-links=$EXTRA_WHEELS --find-links $PRE_WHEELS"
 
 # Add OSX entries to the build matrix
-matrix:
+jobs:
   include:
     - os: osx
       language: generic
@@ -108,10 +108,10 @@ after_script:
 
 deploy:
   provider: pypi
-  user: $PYPI_USER
+  username: $PYPI_USER
   password: $PYPI_PASS
-  skip_cleanup: true
   distributions: "-q sdist bdist_wheel"
   skip_existing: true
+  edge: true
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
+os: linux
 dist: xenial
-sudo: true
 language: python
-cache: false
+cache: pip
 
 # python and global.matrix are crossed to create the base build matrix
 python:
   - 3.5
   - 3.6
   - 3.7
+  - 3.8
 env:
   global:
     - INSTALL_TYPE="pip"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     - EXTRA_WHEELS="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
     - PRE_WHEELS="https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com"
     - CHECK_TYPE="travis_tests"
+    - OSX_MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
   jobs:
     - EXTRA_PIP_FLAGS="--find-links=$EXTRA_WHEELS"
     - EXTRA_PIP_FLAGS="--pre --find-links=$EXTRA_WHEELS --find-links $PRE_WHEELS"
@@ -27,17 +28,18 @@ jobs:
       language: generic
       env:
         - PYTHON_VERSION=3.5
-        - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
     - os: osx
       language: generic
       env:
         - PYTHON_VERSION=3.6
-        - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
     - os: osx
       language: generic
       env:
         - PYTHON_VERSION=3.7
-        - MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
+    - os: osx
+      language: generic
+      env:
+        - PYTHON_VERSION=3.8
     - python: 3.6
       env: CHECK_TYPE=tutorial
     - python: 3.6
@@ -57,8 +59,8 @@ before_install:
         export MINICONDA=$HOME/miniconda;
         export PATH="$MINICONDA/bin:$PATH";
         hash -r;
-        echo $MINICONDA_URL;
-        wget $MINICONDA_URL -O miniconda.sh;
+        echo $OSX_MINICONDA_URL;
+        wget $OSX_MINICONDA_URL -O miniconda.sh;
         bash miniconda.sh -b -s -f -p $MINICONDA;
         conda config --set always_yes yes;
         conda info -a;


### PR DESCRIPTION
Closes #535.

Do we want to follow [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html) or something similar? If so, we should be dropping Python 3.5.

For reference, nibabel and nipype are following NEP29 + 1 year.