### PR TITLE
ENH: Pass kwargs from BIDSImageFile.get_image() to nibabel.load

### DIFF
--- a/bids/layout/models.py
+++ b/bids/layout/models.py
@@ -377,15 +377,17 @@ class BIDSImageFile(BIDSFile):
         'polymorphic_identity': 'image_file'
     }
 
-    def get_image(self):
+    def get_image(self, **kwargs):
         """Return the associated image file (if it exists) as a NiBabel object
+
+        Any keyword arguments are passed to ``nibabel.load``.
         """
         try:
             import nibabel as nb
-            return nb.load(self.path)
-        except Exception:
+            return nb.load(self.path, **kwargs)
+        except Exception as e:
             raise ValueError("'{}' does not appear to be an image format "
-                             "NiBabel can read.".format(self.path))
+                             "NiBabel can read.".format(self.path)) from e
 
 
 class BIDSJSONFile(BIDSFile):


### PR DESCRIPTION
This allows for things like `bids_file.get_image(mmap=False)`.

NBD if this seems out-of-scope. With recent nibabel, `nb.load(bids_file, mmap=False)` works just fine, since we support the `__fspath__` protocol.