### PR TITLE
ENH: Improved handling of invalid filters

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -940,7 +940,7 @@ class BIDSLayout(object):
                     ents = list(entities.keys())
                     suggestions = difflib.get_close_matches(first_bad, ents)
                     if suggestions:
-                        msg += "Did you mean one of {}? ".format(suggestions)
+                        msg += "Did you mean {}? ".format(suggestions)
                     raise ValueError(msg + "If you're sure you want to impose "
                                      "this constraint, set "
                                      "invalid_filters='allow'.")

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -11,6 +11,7 @@ import warnings
 import sqlite3
 import enum
 from pathlib import Path
+import difflib
 
 import sqlalchemy as sa
 from sqlalchemy.orm import joinedload
@@ -848,7 +849,7 @@ class BIDSLayout(object):
         return data.reset_index()
 
     def get(self, return_type='object', target=None, scope='all',
-            regex_search=False, absolute_paths=None, drop_invalid_filters=True,
+            regex_search=False, absolute_paths=None, invalid_filters='drop',
             **filters):
         """Retrieve files and/or metadata from the current Layout.
 
@@ -882,6 +883,14 @@ class BIDSLayout(object):
             to report either absolute or relative (to the top of the
             dataset) paths. If None, will fall back on the value specified
             at BIDSLayout initialization.
+        invalid_filters (str): Controls behavior when named filters are
+            encountered that don't exist in the database (e.g., in the case of
+            a typo like subbject='0.1'). Valid values:
+                'drop' (default): Silently drop invalid filters (equivalent
+                    to not having passed them as arguments in the first place).
+                'allow': Include the invalid filters in the query, resulting
+                    in no results being returned.
+                'error': Raise an explicit error naming the missing filter.
         filters : dict
             Any optional key/values to filter the entities on.
             Keys are entity names, values are regexes to filter on. For
@@ -919,15 +928,21 @@ class BIDSLayout(object):
             exts = listify(filters['extension'])
             filters['extension'] = [x.lstrip('.') for x in exts]
 
-        if drop_invalid_filters:
-            invalid_filters = set(filters.keys()) - set(entities.keys())
-            if invalid_filters:
-                for inv_filt in invalid_filters:
-                    filters.pop(inv_filt)
+        if invalid_filters != 'allow':
+            bad_filters = set(filters.keys()) - set(entities.keys())
+            if bad_filters:
+                if invalid_filters == 'drop':
+                    for bad_filt in bad_filters:
+                        filters.pop(bad_filt)
+                elif invalid_filters == 'error':
+                    first_bad = list(bad_filt)[0]
+                    ents = list(entities.keys())
+                    suggestions = difflib.get_close_matches(first_bad, ents)
+                    raise ValueError("'{}' is not a recognized entity; did you"
+                                     "mean {}?".format(first_bad, suggestions))
 
         # Provide some suggestions if target is specified and invalid.
         if target is not None and target not in entities:
-            import difflib
             potential = list(entities.keys())
             suggestions = difflib.get_close_matches(target, potential)
             if suggestions:

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -935,11 +935,12 @@ class BIDSLayout(object):
                     for bad_filt in bad_filters:
                         filters.pop(bad_filt)
                 elif invalid_filters == 'error':
-                    first_bad = list(bad_filt)[0]
+                    first_bad = list(bad_filters)[0]
                     ents = list(entities.keys())
                     suggestions = difflib.get_close_matches(first_bad, ents)
                     raise ValueError("'{}' is not a recognized entity; did you"
-                                     "mean {}?".format(first_bad, suggestions))
+                                     " mean one of {}?"
+                                     .format(first_bad, suggestions))
 
         # Provide some suggestions if target is specified and invalid.
         if target is not None and target not in entities:

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -671,20 +671,21 @@ def test_get_with_regex_search_bad_dtype(layout_7t_trt):
 
 def test_get_with_invalid_filters(layout_ds005):
     l = layout_ds005
-    res_default = l.get(subject='12', suffix='bold')
-    res_drop = l.get(subject='12', suffix='bold', invalid_filters='drop')
-    assert res_default == res_drop
-    assert len(res_drop) == 3
+    # Raise error with suggestions
+    with pytest.raises(ValueError, match='session'):
+        l.get(subject='12', ses=True, invalid_filters='error')
+    with pytest.raises(ValueError, match='session'):
+        l.get(subject='12', ses=True)
     # Silently drop amazing
-    res_drop = l.get(subject='12', suffix='bold', amazing=True)
-    assert res_default == res_drop
+    res_without = l.get(subject='12', suffix='bold')
+    res_drop = l.get(subject='12', suffix='bold', amazing='!!!',
+                     invalid_filters='drop')
+    assert res_without == res_drop
     assert len(res_drop) == 3
     # Retain amazing, producing empty set
     allow_res = l.get(subject='12', amazing=True, invalid_filters='allow')
     assert allow_res == []
-    # Raise error with suggestions
-    with pytest.raises(ValueError, match='session'):
-        l.get(subject='12', ses=True, invalid_filters='error')
+
 
 
 def test_load_layout(layout_synthetic_nodb, db_dir):

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -668,6 +668,25 @@ def test_get_with_regex_search_bad_dtype(layout_7t_trt):
     # Two runs (1 per session) for each of subjects '10' and '01'
     assert len(results) == 4
 
+
+def test_get_with_invalid_filters(layout_ds005):
+    l = layout_ds005
+    res_default = l.get(subject='12', suffix='bold')
+    res_drop = l.get(subject='12', suffix='bold', invalid_filters='drop')
+    assert res_default == res_drop
+    assert len(res_drop) == 3
+    # Silently drop amazing
+    res_drop = l.get(subject='12', suffix='bold', amazing=True)
+    assert res_default == res_drop
+    assert len(res_drop) == 3
+    # Retain amazing, producing empty set
+    allow_res = l.get(subject='12', amazing=True, invalid_filters='allow')
+    assert allow_res == []
+    # Raise error with suggestions
+    with pytest.raises(ValueError, match='session'):
+        l.get(subject='12', ses=True, invalid_filters='error')
+
+
 def test_load_layout(layout_synthetic_nodb, db_dir):
     db_path = str(db_dir / 'tmp_db')
     layout_synthetic_nodb.save(db_path)

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -40,7 +40,8 @@ def test_index_metadata(index_metadata, query, result):
     if not index_metadata and query is not None:
         indexer = BIDSLayoutIndexer(layout)
         indexer.index_metadata(**query)
-    sample_file = layout.get(task='rest', extension='nii.gz', acq='fullbrain')[0]
+    sample_file = layout.get(task='rest', extension='nii.gz',
+                             acquisition='fullbrain')[0]
     metadata = sample_file.get_metadata()
     assert metadata.get('RepetitionTime') == result
 
@@ -267,24 +268,24 @@ def test_get_return_type_dir(layout_7t_trt, layout_7t_trt_relpath):
 
 @pytest.mark.parametrize("acq", [None, Query.NONE])
 def test_get_val_none(layout_7t_trt, acq):
-    t1w_files = layout_7t_trt.get(subject='01', ses='1', suffix='T1w')
+    t1w_files = layout_7t_trt.get(subject='01', session='1', suffix='T1w')
     assert len(t1w_files) == 1
     assert 'acq' not in t1w_files[0].path
     t1w_files = layout_7t_trt.get(
-        subject='01', ses='1', suffix='T1w', acquisition=acq)
+        subject='01', session='1', suffix='T1w', acquisition=acq)
     assert len(t1w_files) == 1
     bold_files = layout_7t_trt.get(
-        subject='01', ses='1', suffix='bold', acquisition=acq)
+        subject='01', session='1', suffix='bold', acquisition=acq)
     assert len(bold_files) == 0
 
 
 def test_get_val_enum_any(layout_7t_trt):
     t1w_files = layout_7t_trt.get(
-        subject='01', ses='1', suffix='T1w', acquisition=Query.ANY)
+        subject='01', session='1', suffix='T1w', acquisition=Query.ANY)
     assert not t1w_files
-    bold_files = layout_7t_trt.get(subject='01', ses='1', run=1, suffix='bold',
-                                   acquisition=Query.ANY)
-    assert len(bold_files) == 3
+    bold_files = layout_7t_trt.get(subject='01', session='1', run=1,
+                                  suffix='bold', acquisition=Query.ANY)
+    assert len(bold_files) == 2
 
 
 def test_get_return_sorted(layout_7t_trt):


### PR DESCRIPTION
Replaces the `drop_invalid_filters` argument to `BIDSLayout.get()` with an `invalid_filters` argument that behaves as described [here](https://github.com/bids-standard/pybids/issues/596#issuecomment-614238482). Valid options are `'drop'`, `'allow'`, and `'error'`.

This introduces breaking changes, both in terms of the argument name, and the new default behavior (to raise an error, instead of silently dropping invalid filters).

Closes #596.