### PR TITLE
FIX: Bug in BIDSDataFile.get_df()

### DIFF
--- a/bids/layout/models.py
+++ b/bids/layout/models.py
@@ -347,8 +347,10 @@ class BIDSDataFile(BIDSFile):
         # TODO: memoize this for efficiency. (Note: caching is insufficient,
         # because the dtype enforcement will break if we ignore the value of
         # enforce_dtypes).
+        suffix = self.entities['suffix']
+        header = None if suffix in {'physio', 'stim'} else 'infer'
         self.data = pd.read_csv(self.path, sep='\t', na_values='n/a',
-                                dtype=dtype)
+                                dtype=dtype, header=header)
 
         data = self.data.copy()
 

--- a/bids/layout/models.py
+++ b/bids/layout/models.py
@@ -309,7 +309,7 @@ class BIDSDataFile(BIDSFile):
     }
 
     def get_df(self, include_timing=True, adjust_onset=False,
-               enforce_dtypes=True):
+               enforce_dtypes=True, **pd_args):
         """Return the contents of a tsv file as a pandas DataFrame.
 
         Parameters
@@ -326,6 +326,8 @@ class BIDSDataFile(BIDSFile):
             If True, enforces the data types defined in
             the BIDS spec on core columns (e.g., subject_id and session_id
             must be represented as strings).
+        pd_args : dict
+            Optional keyword arguments to pass onto pd.read_csv().
 
         Returns
         -------
@@ -350,7 +352,7 @@ class BIDSDataFile(BIDSFile):
         suffix = self.entities['suffix']
         header = None if suffix in {'physio', 'stim'} else 'infer'
         self.data = pd.read_csv(self.path, sep='\t', na_values='n/a',
-                                dtype=dtype, header=header)
+                                dtype=dtype, header=header, **pd_args)
 
         data = self.data.copy()
 

--- a/bids/layout/tests/test_models.py
+++ b/bids/layout/tests/test_models.py
@@ -176,7 +176,7 @@ def test_bidsfile_get_df_from_tsv_gz(layout_synthetic):
     df1 = bf.get_df()
     df2 = bf.get_df(include_timing=True)
     assert df1.equals(df2)
-    assert df1.shape == (1599, 3)
+    assert df1.shape == (1600, 3)
     assert set(df1.columns) == {'onset', 'respiratory', 'cardiac'}
     assert df1.iloc[0, 0] == 0.
     assert df1.iloc[1, 0] - df1.iloc[0, 0] == 0.1
@@ -190,6 +190,7 @@ def test_bidsfile_get_df_from_tsv_gz(layout_synthetic):
 def test_bidsdatafile_enforces_dtype(layout_synthetic):
     bf = layout_synthetic.get(suffix='participants', extension='tsv')[0]
     df = bf.get_df(enforce_dtypes=False)
+    assert df.shape[0] == 5
     assert df.loc[:, 'subject_id'].dtype == int
     assert df.loc[:, 'subject_id'][0] == 1
     df = bf.get_df(enforce_dtypes=True)


### PR DESCRIPTION
Fixes a bug reading from `.tsv.gz` files in `BIDSDataFile.get_df()`, where the first line was interpreted as a header. Also passes through keyword arguments to `pd.read_csv()`, since we're already doing something similar for NiBabel (see #601).

Closes #570.