### PR TITLE
FIX: Bug in get() when passing enums as extensions

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -903,11 +903,11 @@ class BIDSLayout(object):
 
         entities = self.get_entities()
 
-        # For consistency with past versions where "extensions" was a
-        # hard-coded argument, allow leading periods
+        # Strip leading periods if extensions were passed
         if 'extension' in filters:
             exts = listify(filters['extension'])
-            filters['extension'] = [x.lstrip('.') for x in exts]
+            filters['extension'] = [x.lstrip('.') if isinstance(x, str) else x
+                                    for x in exts]
 
         if drop_invalid_filters:
             invalid_filters = set(filters.keys()) - set(entities.keys())

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -897,17 +897,7 @@ class BIDSLayout(object):
         -------
         list of :obj:`bids.layout.BIDSFile` or str
             A list of BIDSFiles (default) or strings (see return_type).
-
-        Notes
-        -----
-        * In pybids 0.9.0, the 'extensions' argument has been removed in
-          favor of the 'extension' entity.
         """
-        if 'extensions' in filters:
-            filters['extension'] = filters.pop('extensions')
-            warnings.warn("In pybids 0.9.0, the 'extensions' filter was "
-                          "deprecated in favor of 'extension'. The former will"
-                          " stop working in 0.11.0.", DeprecationWarning)
 
         layouts = self._get_layouts_in_scope(scope)
 

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -280,7 +280,8 @@ def test_get_val_none(layout_7t_trt, acq):
 
 def test_get_val_enum_any(layout_7t_trt):
     t1w_files = layout_7t_trt.get(
-        subject='01', ses='1', suffix='T1w', acquisition=Query.ANY)
+        subject='01', ses='1', suffix='T1w', acquisition=Query.ANY,
+        extension=Query.ANY)
     assert not t1w_files
     bold_files = layout_7t_trt.get(subject='01', ses='1', run=1, suffix='bold',
                                    acquisition=Query.ANY)


### PR DESCRIPTION
Closes #603. Also removes deprecation warning about `extensions` disappearing in 0.11, as we're about to release 0.11.