### PR TITLE
ENH: Adds OS-level file copying instead of reading/writing via Python

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -1585,9 +1585,9 @@ class BIDSLayout(object):
                    root=self.root, conflicts=conflicts)
 
     def write_to_file(self, entities, path_patterns=None,
-                               contents=None, link_to=None, copy_from=None,
-                               content_mode='text', conflicts='fail',
-                               strict=False, validate=True):
+                      contents=None, link_to=None, copy_from=None,
+                      content_mode='text', conflicts='fail',
+                      strict=False, validate=True):
         """Write data to a file defined by the passed entities and patterns.
 
         Parameters
@@ -1632,8 +1632,8 @@ class BIDSLayout(object):
                              "patterns.")
 
         write_to_file(path, contents=contents, link_to=link_to,
-                               copy_from=copy_from, content_mode=content_mode,
-                               conflicts=conflicts, root=self.root)
+                      copy_from=copy_from, content_mode=content_mode,
+                      conflicts=conflicts, root=self.root)
 
 
 class Query(enum.Enum):

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -19,7 +19,7 @@ from bids_validator import BIDSValidator
 
 from ..utils import listify, natural_sort, make_bidsfile
 from ..external import inflect
-from .writing import build_path, write_contents_to_file
+from .writing import build_path, write_to_file
 from .models import (Base, Config, BIDSFile, Entity, Tag)
 from .index import BIDSLayoutIndexer
 from .utils import BIDSMetadata
@@ -1584,12 +1584,11 @@ class BIDSLayout(object):
             f.copy(path_patterns, symbolic_link=symbolic_links,
                    root=self.root, conflicts=conflicts)
 
-    def write_contents_to_file(self, entities, path_patterns=None,
-                               contents=None, link_to=None,
+    def write_to_file(self, entities, path_patterns=None,
+                               contents=None, link_to=None, copy_from=None,
                                content_mode='text', conflicts='fail',
                                strict=False, validate=True):
-        """Write arbitrary data to a file defined by the passed entities and
-        path patterns.
+        """Write data to a file defined by the passed entities and patterns.
 
         Parameters
         ----------
@@ -1632,9 +1631,9 @@ class BIDSLayout(object):
                              "the passed entities given available path "
                              "patterns.")
 
-        write_contents_to_file(path, contents=contents, link_to=link_to,
-                               content_mode=content_mode, conflicts=conflicts,
-                               root=self.root)
+        write_to_file(path, contents=contents, link_to=link_to,
+                               copy_from=copy_from, content_mode=content_mode,
+                               conflicts=conflicts, root=self.root)
 
 
 class Query(enum.Enum):

--- a/bids/layout/models.py
+++ b/bids/layout/models.py
@@ -12,7 +12,7 @@ import json
 from copy import deepcopy
 from itertools import chain
 
-from .writing import build_path, write_contents_to_file
+from .writing import build_path, write_to_file
 from ..config import get_option
 from .utils import BIDSMetadata
 
@@ -284,17 +284,13 @@ class BIDSFile(Base):
             raise ValueError("Target filename to copy/symlink (%s) doesn't "
                              "exist." % path)
 
+        kwargs = dict(path=new_filename, root=root, conflicts=conflicts)
         if symbolic_link:
-            contents = None
-            link_to = path
+            kwargs['link_to'] = path
         else:
-            with open(path, 'r') as f:
-                contents = f.read()
-            link_to = None
+            kwargs['copy_from'] = path
 
-        write_contents_to_file(new_filename, contents=contents,
-                               link_to=link_to, content_mode='text', root=root,
-                               conflicts=conflicts)
+        write_to_file(**kwargs)
 
 
 class BIDSDataFile(BIDSFile):

--- a/bids/layout/tests/test_writing.py
+++ b/bids/layout/tests/test_writing.py
@@ -304,11 +304,11 @@ class TestWritableLayout:
         layout.copy_files(path_patterns=pat, conflicts='overwrite')
         assert exists(example_file)
 
-    def test_write_contents_to_file(self, tmp_bids, layout):
+    def test_write_to_file(self, tmp_bids, layout):
         contents = 'test'
         entities = {'subject': 'Bob', 'session': '01'}
         pat = join('sub-{subject}/ses-{session}/desc.txt')
-        layout.write_contents_to_file(entities, path_patterns=pat,
+        layout.write_to_file(entities, path_patterns=pat,
                                       contents=contents, validate=False)
         target = join(str(tmp_bids), 'bids', 'sub-Bob/ses-01/desc.txt')
         assert exists(target)
@@ -317,12 +317,12 @@ class TestWritableLayout:
         assert written == contents
         assert target not in layout.files
 
-    def test_write_contents_to_file_defaults(self, tmp_bids, layout):
+    def test_write_to_file_defaults(self, tmp_bids, layout):
         contents = 'test'
         entities = {'subject': 'Bob', 'session': '01', 'run': '1',
                     'suffix': 'bold', 'task': 'test', 'acquisition': 'test',
                     'bval': 0}
-        layout.write_contents_to_file(entities, contents=contents)
+        layout.write_to_file(entities, contents=contents)
         target = join(str(tmp_bids), 'bids', 'sub-Bob', 'ses-01',
                       'func', 'sub-Bob_ses-01_task-test_acq-test_run-1_bold.nii.gz')
         assert exists(target)

--- a/bids/layout/writing.py
+++ b/bids/layout/writing.py
@@ -282,7 +282,7 @@ def write_to_file(path, contents=None, link_to=None, copy_from=None,
         with open(path, mode) as f:
             f.write(contents)
     else:
-        raise ValueError('One of contents or link_to must be provided.')
+        raise ValueError('One of contents, copy_from or link_to must be provided.')
 
 
 def _expand_options(value):


### PR DESCRIPTION
For historical reasons, `BIDSFile.copy()` only supported copying text files, and did so by reading contents in and then writing them. This patch generalizes the previous workhorse `write_contents_to_file()` function to add support for direct copying. As a result, I've renamed it to `write_to_file()`.

Closes #514