### PR TITLE
ENH: Introduce PyBIDS exceptions

### DIFF
--- a/bids/exceptions.py
+++ b/bids/exceptions.py
@@ -29,7 +29,7 @@ class BIDSValidationError(ValueError, PyBIDSError):
     """ An invalid BIDS dataset. """
 
 
-class BIDSDerivativesValidationError(BIDSValidationError, PyBIDSError):
+class BIDSDerivativesValidationError(BIDSValidationError):
     """ An invalid BIDS derivative dataset. """
 
 

--- a/bids/exceptions.py
+++ b/bids/exceptions.py
@@ -1,0 +1,37 @@
+""" Exceptions.
+
+Exceptions relating to problems with BIDS itself, should carry BIDS in their
+name.  All exceptions should subclass from PyBIDSError
+"""
+
+
+class PyBIDSError(Exception):
+    """ Base class.  Typically for mix-in."""
+
+
+class ConfigError(ValueError, PyBIDSError):
+    """ Problems with config file. """
+
+
+class NoMatchError(ValueError, PyBIDSError):
+    """ No match found where it is required. """
+
+
+class BIDSEntityError(AttributeError, PyBIDSError):
+    """ An unknown entity. """
+
+
+class TargetError(ValueError, PyBIDSError):
+    """ An unknown target. """
+
+
+class BIDSValidationError(ValueError, PyBIDSError):
+    """ An invalid BIDS dataset. """
+
+
+class BIDSDerivativesValidationError(BIDSValidationError, PyBIDSError):
+    """ An invalid BIDS derivative dataset. """
+
+
+class BIDSConflictingValuesError(BIDSValidationError):
+    """ A value conflict (e.g. in filename and side-car .json) """

--- a/bids/layout/index.py
+++ b/bids/layout/index.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from bids_validator import BIDSValidator
 from .models import Config, Entity, Tag, FileAssociation
 from ..utils import listify, make_bidsfile
+from ..exceptions import BIDSConflictingValuesError
 
 
 def _extract_entities(bidsfile, entities):
@@ -367,8 +368,9 @@ class BIDSLayoutIndexer(object):
                             "filename {} (value='{}') versus its JSON sidecar "
                             "(value='{}'). Please reconcile this discrepancy."
                         )
-                        raise ValueError(msg.format(md_key, bf.path, file_val,
-                                                    md_val))
+                        raise BIDSConflictingValuesError(
+                            msg.format(md_key, bf.path, file_val,
+                            md_val))
                     continue
                 if md_key not in all_entities:
                     all_entities[md_key] = Entity(md_key, is_metadata=True)

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -320,7 +320,7 @@ class BIDSLayout(object):
                         "recognized entity name.".format(ent_name, ent_name))
             return partial(self.get, return_type='id', target=ent_name)
         # Spit out default message if we get this far
-        raise BIDSEntityError("%s object has no attribute named %r" %
+        raise AttributeError("%s object has no attribute named %r" %
                              (self.__class__.__name__, key))
 
     def __repr__(self):

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -18,6 +18,13 @@ from bids.layout.utils import BIDSMetadata
 from bids.tests import get_test_data_path
 from bids.utils import natural_sort
 
+from bids.exceptions import (
+    BIDSValidationError,
+    ConfigError,
+    NoMatchError,
+    TargetError,
+)
+
 
 def test_layout_init(layout_7t_trt):
     assert isinstance(layout_7t_trt.files, dict)
@@ -193,11 +200,11 @@ def test_get_metadata_error(layout_7t_trt):
 
 
 def test_get_with_bad_target(layout_7t_trt):
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(TargetError) as exc:
         layout_7t_trt.get(target='unicorn')
         msg = exc.value.message
         assert 'subject' in msg and 'reconstruction' in msg and 'proc' in msg
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(TargetError) as exc:
         layout_7t_trt.get(target='sub')
         msg = exc.value.message
         assert 'subject' in msg and 'reconstruction' not in msg
@@ -439,11 +446,11 @@ def test_derivative_getters():
 
 def test_get_tr(layout_7t_trt):
     # Bad subject, should fail
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(NoMatchError) as exc:
         layout_7t_trt.get_tr(subject="zzz")
         assert exc.value.message.startswith("No functional images")
     # There are multiple tasks with different TRs, so this should fail
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(NoMatchError) as exc:
         layout_7t_trt.get_tr(subject=['01', '02'])
         assert exc.value.message.startswith("Unique TR")
     # This should work
@@ -542,10 +549,10 @@ def test_deriv_indexing():
 def test_add_config_paths():
     bids_dir = dirname(bids.__file__)
     bids_json = os.path.join(bids_dir, 'layout', 'config', 'bids.json')
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(ConfigError) as exc:
         add_config_paths(test_config1='nonexistentpath.json')
     assert str(exc.value).startswith('Configuration file')
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(ConfigError) as exc:
         add_config_paths(bids=bids_json)
     assert str(exc.value).startswith("Configuration 'bids' already")
     add_config_paths(dummy=bids_json)
@@ -624,7 +631,7 @@ def test_layout_save(tmp_path, layout_7t_trt):
 
 def test_indexing_tag_conflict():
     data_dir = join(get_test_data_path(), 'ds005_conflict')
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(BIDSValidationError) as exc:
         layout = BIDSLayout(data_dir)
         print(exc.value.message)
         assert exc.value.message.startswith("Conflicting values found")


### PR DESCRIPTION
This is an initial shot, which Closes #473 if merged since original concern would be addressed.

But
- I wonder if I have not overdone it a bit ;-)
- I think that many (if not all) of the `*BIDS*` exceptions should have ideally came from `bids_validator` package, and were not defined in PyBIDS
- I might have (or not) misinterpreted/attributed difference between "entity" (BIDS term) and target (more of a PyBIDS term).

But looking at the tests I think it becomes a bit clearer on what to expect to be raised, in comparison to IMHO abused `ValueError` (could come from anywhere).  I might have even made `BIDSValidationError` not a subclass of `ValueError` since we are not really talking about a value passed into a function in pybids (which is what typically ValueError is used for, and what I left it used for in a number of places), but rather about an entity on the harddrive (the BIDS dataset). 