### PR TITLE
FIX: Certain queries involving multiple layouts are very slow

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -931,10 +931,6 @@ class BIDSLayout(object):
         for l in layouts:
             query = l._build_file_query(filters=filters,
                                         regex_search=regex_search)
-            # Eager load associations, because mixing queries from different
-            # DB sessions causes objects to detach
-            query = query.options(joinedload(BIDSFile.tags)
-                                  .joinedload(Tag.entity))
             results.extend(query.all())
 
         # Convert to relative paths if needed


### PR DESCRIPTION
See #533 for problem description. The solution was weirdly trivial: I removed eager loading of `BIDSFile` and `Tag` associations in the query-building. It makes sense that this would dramatically speed things up for queries over large datasets (as these tables can get pretty big); the surprise is that this doesn't break anything, as I only introduced the eager joining in order to solve some earlier problems with SQLite connections detaching when mixing databases. My best guess would have been that SQLAlchemy fixed something in a recent version, but it turns out I was still running 1.3.8 (over a year old) until just now. So I'm frankly at a loss. But as long as this doesn't cause any test failures on Travis, and nobody else complains, I think this is the sensible course of action, as it should speed a *lot* of queries up.

Closes #533 