### PR TITLE
CI: Drop --pre check for Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,9 @@ jobs:
       env:
         - SETUP_REQUIRES="pip==10.0.1 setuptools==30.4.0"
         - CHECK_TYPE=skiptests
+  exclude:
+    - python: 3.5
+      env: EXTRA_PIP_FLAGS="--pre --find-links=$EXTRA_WHEELS --find-links $PRE_WHEELS"
 
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then


### PR DESCRIPTION
Travis is failing because numpy 1.19rc1 is being installed but there are no wheels for Python 3.5.