### PR TITLE
Add explicit warning message when users pass in filters as a dictionary keyword

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -937,6 +937,14 @@ class BIDSLayout(object):
 
         entities = self.get_entities()
 
+        # error check on users accidentally passing in filters
+        if 'filters' in filters:
+            if isinstance(filters['filters'], dict):
+                raise RuntimeError('You passed in filters as a dictionary '
+                                   'named filters; please pass the keys in '
+                                   'as named keywords to the `get()` call. '
+                                   'For example: `layout.get(**filters)`.')
+
         # Strip leading periods if extensions were passed
         if 'extension' in filters:
             exts = listify(filters['extension'])

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -938,12 +938,11 @@ class BIDSLayout(object):
         entities = self.get_entities()
 
         # error check on users accidentally passing in filters
-        if 'filters' in filters:
-            if isinstance(filters['filters'], dict):
-                raise RuntimeError('You passed in filters as a dictionary '
-                                   'named filters; please pass the keys in '
-                                   'as named keywords to the `get()` call. '
-                                   'For example: `layout.get(**filters)`.')
+        if isinstance(filters.get('filters'), dict):
+            raise RuntimeError('You passed in filters as a dictionary named '
+                               'filters; please pass the keys in as named '
+                               'keywords to the `get()` call. For example: '
+                               '`layout.get(**filters)`.')
 
         # Strip leading periods if extensions were passed
         if 'extension' in filters:

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -688,6 +688,12 @@ def test_get_with_invalid_filters(layout_ds005):
     allow_res = l.get(subject='12', amazing=True, invalid_filters='allow')
     assert allow_res == []
 
+    # assert warning when filters are passed in
+    filters = {
+        'subject': '1',
+    }
+    with pytest.raises(RuntimeError, match='You passed in filters as a dictionary'):
+        l.get(filters=filters)
 
 
 def test_load_layout(layout_synthetic_nodb, db_dir):

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -689,11 +689,11 @@ def test_get_with_invalid_filters(layout_ds005):
     assert allow_res == []
 
     # assert warning when filters are passed in
-    filters = {
-        'subject': '1',
-    }
+    filters = {'subject': '1'}
     with pytest.raises(RuntimeError, match='You passed in filters as a dictionary'):
         l.get(filters=filters)
+    # Correct call:
+    l.get(**filters)
 
 
 def test_load_layout(layout_synthetic_nodb, db_dir):


### PR DESCRIPTION
Closes: #622 

Helps direct users to not pass in `filters` as a dictionary directly, but should have them do:

`layout.get(**filters)`

vs

`layout.get(filters=filters)`, which results in returning the entire bids root.