### PR TITLE
Fix divide by zero error when only single onset in event

### DIFF
--- a/bids/variables/variables.py
+++ b/bids/variables/variables.py
@@ -383,7 +383,11 @@ class SparseRunVariable(SimpleVariable):
             # Cast onsets and durations to milliseconds
             onsets = np.round(self.onset * 1000).astype(int)
             durations = np.round(self.duration * 1000).astype(int)
-            sampling_rate = 1000. / reduce(math.gcd, [*onsets, *durations])
+            red = reduce(math.gcd, [*onsets, *durations])
+            if red > 0:
+                sampling_rate = 1000. / reduce(math.gcd, [*onsets, *durations])
+            else:
+                sampling_rate = 1
 
         duration = int(math.ceil(sampling_rate * self.get_duration()))
         ts = np.zeros(duration, dtype=self.values.dtype)


### PR DESCRIPTION
If there is an even with only a single onset, the computation to determine the appropriate sampling_rate to not lose fidelity fails (divide by zero error).

Here, I just add a simple check to set the `sampling_rate` to 1, if the divisor of that computation is zero. 
This is just an arbitrary rate I picked, but it works, and it shouldn't matter since the event only has a single event. 