### PR TITLE
FIX: Post-fix And and Or transformations with underscore

### DIFF
--- a/bids/analysis/transformations/__init__.py
+++ b/bids/analysis/transformations/__init__.py
@@ -4,7 +4,11 @@ from .munge import (Split, Rename, Assign, Copy, Factor, Filter, Select,
                     Delete, DropNA, Replace, ToDense, Group, Resample)
 from .base import TransformerManager
 
+And = And_
+Or = Or_
+
 __all__ = [
+    'And',
     'And_',
     'Assign',
     'Convolve',
@@ -16,6 +20,7 @@ __all__ = [
     'Filter',
     'Group',
     'Not',
+    'Or',
     'Or_',
     'Orthogonalize',
     'Product',

--- a/bids/analysis/transformations/__init__.py
+++ b/bids/analysis/transformations/__init__.py
@@ -1,11 +1,11 @@
-from .compute import (Sum, Product, Scale, Orthogonalize, Threshold, And, Or,
+from .compute import (Sum, Product, Scale, Orthogonalize, Threshold, And_, Or_,
                       Not, Demean, Convolve)
 from .munge import (Split, Rename, Assign, Copy, Factor, Filter, Select,
                     Delete, DropNA, Replace, ToDense, Group, Resample)
 from .base import TransformerManager
 
 __all__ = [
-    'And',
+    'And_',
     'Assign',
     'Convolve',
     'Copy',
@@ -16,7 +16,7 @@ __all__ = [
     'Filter',
     'Group',
     'Not',
-    'Or',
+    'Or_',
     'Orthogonalize',
     'Product',
     'Rename',

--- a/bids/analysis/transformations/compute.py
+++ b/bids/analysis/transformations/compute.py
@@ -223,7 +223,7 @@ class Threshold(Transformation):
         return data
 
 
-class And(Transformation):
+class And_(Transformation):
     """Logical AND on two or more variables.
 
     Parameters
@@ -257,7 +257,7 @@ class Not(Transformation):
         return ~var.astype(bool)
 
 
-class Or(Transformation):
+class Or_(Transformation):
     """Logical OR (inclusive) on two or more variables.
 
     Parameters


### PR DESCRIPTION
#548 created a TransformerManager that normalized transformation names to lowercase, which would make `And` and `Or` conflict with the keywords `and` and `or`, so it postfixed these with underscores.

This PR applies the change to the `Transformation` subclasses, as well.

@tyarkoni Any reason to keep `And` and `Or` around as aliases?