### PR TITLE
FIX: Preserve `get` logic when using custom config

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -955,7 +955,7 @@ class BIDSLayout(object):
                                '`layout.get(**filters)`.')
 
         # Strip leading periods if extensions were passed
-        if 'extension' in filters:
+        if 'extension' in filters and 'bids' in self.config:
             # XXX 0.14: Disable drop_dot option
             drop_dot = (self.config['bids'].entities['extension'].pattern ==
                         '[._]*[a-zA-Z0-9]*?\\.([^/\\\\]+)$')


### PR DESCRIPTION
Closes #635 

Adds a check for the default config before querying it.

This is causing a failure within the templateflow client (and subsequently fmriprep + friends), so we should cut a new release once this is in.