### PR TITLE
ENH: Catch any NIfTI/GIFTI (incl. CIFTI-2) files as BIDSImageFiles

### DIFF
--- a/bids/utils.py
+++ b/bids/utils.py
@@ -95,16 +95,16 @@ def make_bidsfile(filename):
     """Create a BIDSFile instance of the appropriate class. """
     from .layout import models
 
-    patt = re.compile("[._]*[a-zA-Z0-9]*?\\.([^/\\\\]+)$")
+    patt = re.compile("[._]*[a-zA-Z0-9]*?(\\.[^/\\\\]+)$")
     m = re.search(patt, filename)
 
     ext = None if not m else m.group(1)
 
-    if ext in ['nii', 'nii.gz']:
+    if ext is not None and ext.endswith(('.nii', '.nii.gz', '.gii')):
         cls = 'BIDSImageFile'
-    elif ext in ['tsv', 'tsv.gz']:
+    elif ext in ['.tsv', '.tsv.gz']:
         cls = 'BIDSDataFile'
-    elif ext == 'json':
+    elif ext == '.json':
         cls = 'BIDSJSONFile'
     else:
         cls = 'BIDSFile'

--- a/bids/utils.py
+++ b/bids/utils.py
@@ -98,9 +98,9 @@ def make_bidsfile(filename):
     patt = re.compile("[._]*[a-zA-Z0-9]*?(\\.[^/\\\\]+)$")
     m = re.search(patt, filename)
 
-    ext = None if not m else m.group(1)
+    ext = '' if not m else m.group(1)
 
-    if ext is not None and ext.endswith(('.nii', '.nii.gz', '.gii')):
+    if ext.endswith(('.nii', '.nii.gz', '.gii')):
         cls = 'BIDSImageFile'
     elif ext in ['.tsv', '.tsv.gz']:
         cls = 'BIDSDataFile'


### PR DESCRIPTION
This helps ensure that double-extensions like `.dtseries.nii` or `.func.gii` get identified as neuroimages.

Backwards compatible, as file objects might become subclasses of their original objects, but won't go the other way.