### PR TITLE
Add example for using parse_file_entities from bids.layout

### DIFF
--- a/examples/pybids_tutorial.ipynb
+++ b/examples/pybids_tutorial.ipynb
@@ -724,13 +724,43 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "A version of this utility independent of a specific layout is available at `bids.layout` ([doc](https://bids-standard.github.io/pybids/generated/bids.layout.parse_file_entities.html#bids.layout.parse_file_entities)) - "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'extension': 'nii.gz', 'run': 1, 'subject': '01', 'suffix': 'T2w'}"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from bids.layout import parse_file_entities\n",
+    "\n",
+    "path = \"/a/fake/path/to/a/BIDS/file/sub-01_run-1_T2w.nii.gz\"\n",
+    "parse_file_entities(path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Path construction\n",
     "You may want to create valid BIDS filenames for files that are new or hypothetical that would sit within your BIDS project. This is useful when you know what entity values you need to write out to, but don't want to deal with looking up the precise BIDS file-naming syntax. In the example below, imagine we've created a new file containing stimulus presentation information, and we want to save it to a `.tsv.gz` file, per the BIDS naming conventions. All we need to do is define a dictionary with the name components, and `build_path` takes care of the rest (including injecting sub-directories!):"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2018-08-01T20:05:24.049418Z",
@@ -744,7 +774,7 @@
        "'sub-01/func/sub-01_task-nback_run-2_bold.nii.gz'"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -775,7 +805,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -784,7 +814,7 @@
        "'sub-01_task-nback_run-2_z.nii.gz'"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -822,7 +852,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2018-08-01T20:05:24.228683Z",
@@ -836,7 +866,7 @@
        "BIDS Layout: ...bids/bids/tests/data/synthetic | Subjects: 5 | Sessions: 10 | Runs: 10"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -859,7 +889,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2018-08-01T20:05:24.245649Z",
@@ -1146,7 +1176,7 @@
        " '/Users/tal/Dropbox/Code/pybids/bids/tests/data/synthetic/derivatives/fmriprep/task-rest_bold.json']"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1166,7 +1196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2018-08-01T20:05:24.275066Z",
@@ -1307,7 +1337,7 @@
        "4         magnitude1  NaN  "
       ]
      },
-     "execution_count": 21,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1327,7 +1357,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -1532,7 +1562,7 @@
        "[5 rows x 25 columns]"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1553,7 +1583,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2018-08-01T20:05:26.693372Z",
@@ -1770,7 +1800,7 @@
        "[5 rows x 97 columns]"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1792,40 +1822,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2018-08-01T20:05:27.763448Z",
      "start_time": "2018-08-01T20:05:27.749652Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "from bids import BIDSValidator\n",
-    "\n",
-    "# Note that when using the bids validator, the filepath MUST be relative to the top level bids directory\n",
-    "validator = BIDSValidator()\n",
-    "validator.is_bids('/sub-02/ses-01/anat/sub-02_ses-01_T2w.nii.gz')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2018-08-01T20:05:27.773052Z",
-     "start_time": "2018-08-01T20:05:27.765263Z"
     }
    },
    "outputs": [
@@ -1841,14 +1842,22 @@
     }
    ],
    "source": [
-    "# Can decide if a filepath represents a file part of the specification\n",
-    "validator.is_file('/sub-02/ses-01/anat/sub-02_ses-01_T2w.json')"
+    "from bids import BIDSValidator\n",
+    "\n",
+    "# Note that when using the bids validator, the filepath MUST be relative to the top level bids directory\n",
+    "validator = BIDSValidator()\n",
+    "validator.is_bids('/sub-02/ses-01/anat/sub-02_ses-01_T2w.nii.gz')"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 26,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-08-01T20:05:27.773052Z",
+     "start_time": "2018-08-01T20:05:27.765263Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -1862,8 +1871,8 @@
     }
    ],
    "source": [
-    "# Can check if a file is at the top level of the dataset\n",
-    "validator.is_top_level('/dataset_description.json')"
+    "# Can decide if a filepath represents a file part of the specification\n",
+    "validator.is_file('/sub-02/ses-01/anat/sub-02_ses-01_T2w.json')"
    ]
   },
   {
@@ -1874,10 +1883,31 @@
     {
      "data": {
       "text/plain": [
-       "False"
+       "True"
       ]
      },
      "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Can check if a file is at the top level of the dataset\n",
+    "validator.is_top_level('/dataset_description.json')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1889,7 +1919,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -1898,7 +1928,7 @@
        "True"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1909,7 +1939,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 30,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2018-08-01T20:05:27.780022Z",
@@ -1923,7 +1953,7 @@
        "False"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
This illustrates using this util independent of a specific layout. This change also includes the change in execution count of the subsequent code cells.

As suggested in #633 [(comment)](https://github.com/bids-standard/pybids/issues/633#issuecomment-654319454)