### PR TITLE
FIX: Remove need to eager load associations

### DIFF
--- a/bids/layout/__init__.py
+++ b/bids/layout/__init__.py
@@ -1,6 +1,7 @@
-from .layout import BIDSLayout, add_config_paths, parse_file_entities, Query
+from .layout import BIDSLayout, Query
 from .models import (BIDSFile, BIDSImageFile, BIDSDataFile, BIDSJSONFile,
                      Config, Entity, Tag)
+from .utils import add_config_paths, parse_file_entities
 # Backwards compatibility
 from bids_validator import BIDSValidator
 

--- a/bids/layout/db.py
+++ b/bids/layout/db.py
@@ -1,0 +1,137 @@
+"""
+Database-related functionality.
+"""
+
+from pathlib import Path
+import json
+import re
+import warnings
+from functools import lru_cache
+
+import sqlalchemy as sa
+from sqlalchemy.orm import joinedload
+
+from bids.utils import listify
+from .models import Base, Config
+
+
+def _make_db_path(path):
+    if path is not None:
+        path = Path(path)
+        database_file = path / 'layout_index.sqlite'
+        path.mkdir(exist_ok=True, parents=True)
+    else:
+        database_file = None
+    return database_file
+
+
+class ConnectionManager:
+
+    def __init__(self, database_path=None, reset_database=False, config=None,
+                 init_args=None):
+
+        self.database_file = _make_db_path(database_path)
+        self.engine = self._get_engine(self.database_file)
+        self.sessionmaker = sa.orm.sessionmaker(bind=self.engine)
+        self._session = None
+
+        # Determine whether to reset DB or load from file
+        reset_database = (
+            reset_database or  # Manual Request
+            not self.database_file or  # In memory transient db
+            not self.database_file.exists()  # New file-based db created
+        )
+
+        if reset_database:
+            self.reset_database(init_args, config)
+        else:
+            self.load_database(init_args)
+
+    def _get_engine(self, database_file):
+        if database_file is not None:
+            # https://docs.sqlalchemy.org/en/13/dialects/sqlite.html
+            # When a file-based database is specified, the dialect will use
+            # NullPool as the source of connections. This pool closes and
+            # discards connections which are returned to the pool immediately.
+            # SQLite file-based connections have extremely low overhead, so
+            # pooling is not necessary. The scheme also prevents a connection
+            # from being used again in a different thread and works best
+            # with SQLite's coarse-grained file locking.
+            from sqlalchemy.pool import NullPool
+            engine = sa.create_engine(
+                'sqlite:///{dbfilepath}'.format(dbfilepath=database_file),
+                connect_args={'check_same_thread': False},
+                poolclass=NullPool)
+        else:
+            # https://docs.sqlalchemy.org/en/13/dialects/sqlite.html
+            # Using a Memory Database in Multiple Threads
+            # To use a :memory: database in a multithreaded scenario, the same
+            # connection object must be shared among threads, since the
+            # database exists only within the scope of that connection. The
+            # StaticPool implementation will maintain a single connection
+            # globally, and the check_same_thread flag can be passed to
+            # Pysqlite as False. Note that using a :memory: database in
+            # multiple threads requires a recent version of SQLite.
+            from sqlalchemy.pool import StaticPool
+            engine = sa.create_engine(
+                'sqlite://',  # In memory database
+                connect_args={'check_same_thread': False},
+                poolclass=StaticPool)
+            
+        def regexp(expr, item):
+            """Regex function for SQLite's REGEXP."""
+            reg = re.compile(expr, re.I)
+            return reg.search(item) is not None
+
+        engine.connect()
+
+        # Do not remove this decorator!!! An in-line create_function call will
+        # work when using an in-memory SQLite DB, but fails when using a file.
+        # For more details, see https://stackoverflow.com/questions/12461814/
+        @sa.event.listens_for(engine, "begin")
+        def do_begin(conn):
+            conn.connection.create_function('regexp', 2, regexp)
+
+        return engine
+
+    def reset_database(self, init_args=None, config=None):
+        init_args = init_args or {}
+        Base.metadata.drop_all(self.engine)
+        Base.metadata.create_all(self.engine)
+        if self.database_sidecar is not None:
+            self.database_sidecar.write_text(json.dumps(init_args))
+        # Add config records
+        config = listify('bids' if config is None else config)
+        config = [Config.load(c, session=self.session) for c in listify(config)]
+        self.session.add(*config)
+        self.session.commit()
+
+    def load_database(self, init_args=None):
+        if self.database_file is None:
+            raise ValueError("load_database() can only be called on databases "
+                             "stored in a file, not on in-memory databases.")
+        init_args = init_args or {}
+        saved_args = json.loads(self.database_sidecar.read_text())
+        for k, v in saved_args.items():
+            if init_args[k] != v:
+                raise ValueError(
+                    "Initialization argument ('{}') does not match "
+                    "for database_path: {}.\n"
+                    "Saved value: {}.\n"
+                    "Current value: {}.".format(
+                        k, self.database_file, v, init_args[k])
+                    )  
+
+    @property
+    # Replace with @cached_property (3.8+) at some point in future
+    @lru_cache(maxsize=None)
+    def database_sidecar(self):
+        if self.database_file is not None:
+            return self.database_file.parent() / 'layout_args.json'
+        return None
+
+    @property
+    def session(self):
+        if self._session is None:
+            self._session = self.sessionmaker()
+        return self._session

--- a/bids/layout/db.py
+++ b/bids/layout/db.py
@@ -139,7 +139,7 @@ class ConnectionManager:
         # Add config records
         config = listify('bids' if config is None else config)
         config = [Config.load(c, session=self.session) for c in listify(config)]
-        self.session.add(*config)
+        self.session.add_all(config)
         self.session.commit()
 
     def load_database(self):

--- a/bids/layout/db.py
+++ b/bids/layout/db.py
@@ -41,9 +41,8 @@ def _sanitize_init_args(**kwargs):
     """ Prepare initalization arguments for serialization """
     # Make ignore and force_index serializable
     for k in ['ignore', 'force_index']:
-        kwargs[k] = [
-            str(a) for a in kwargs.get(k) if a is not None] \
-            if kwargs.get(k) is not None else None
+        if kwargs.get(k) is not None:
+            kwargs[k] = [str(a) for a in kwargs.get(k) if a is not None]
 
     if 'root' in kwargs:
         kwargs['root'] = str(Path(kwargs['root']).absolute())

--- a/bids/layout/db.py
+++ b/bids/layout/db.py
@@ -24,6 +24,16 @@ def _make_db_path(path):
         database_file = None
     return database_file
 
+def get_database_sidecar(path):
+    """Given a path to a database file, return the associated sidecar.
+
+    Args:
+        path (str, Path): A path to a database file
+    """
+    if isinstance(path, str):
+        path = Path(path)
+    return path.parent() / 'layout_args.json'
+
 
 class ConnectionManager:
 
@@ -127,11 +137,15 @@ class ConnectionManager:
     @lru_cache(maxsize=None)
     def database_sidecar(self):
         if self.database_file is not None:
-            return self.database_file.parent() / 'layout_args.json'
+            return get_database_sidecar(self.database_file)
         return None
 
     @property
     def session(self):
         if self._session is None:
-            self._session = self.sessionmaker()
+            self.reset_session()
         return self._session
+
+    def reset_session(self):
+        """Force a new session."""
+        self._session = self.sessionmaker()

--- a/bids/layout/index.py
+++ b/bids/layout/index.py
@@ -77,7 +77,7 @@ class BIDSLayoutIndexer(object):
 
         # Derivatives are currently not validated.
         # TODO: raise warning the first time in a session this is encountered
-        if not self.validate or 'derivatives' in self.config:
+        if not self.validate or 'derivatives' in self.layout.config:
             return True
 
         # BIDS validator expects absolute paths, but really these are relative

--- a/bids/layout/index.py
+++ b/bids/layout/index.py
@@ -46,13 +46,13 @@ class BIDSLayoutIndexer(object):
     def __init__(self, layout):
 
         self.layout = layout
+        self.config = list(layout.config.values())
         self.session = layout.session
         self.validate = layout.validate
         self.root = layout.root
         self.config_filename = layout.config_filename
         self.validator = BIDSValidator(index_associated=True)
         # Create copies of list attributes we'll modify during indexing
-        self.config = list(layout.config.values())
         self.include_patterns = list(layout.force_index)
         self.exclude_patterns = list(layout.ignore)
 
@@ -77,7 +77,7 @@ class BIDSLayoutIndexer(object):
 
         # Derivatives are currently not validated.
         # TODO: raise warning the first time in a session this is encountered
-        if not self.validate or 'derivatives' in self.layout.config:
+        if not self.validate or 'derivatives' in self.config:
             return True
 
         # BIDS validator expects absolute paths, but really these are relative
@@ -164,11 +164,11 @@ class BIDSLayoutIndexer(object):
 
         return bf
 
-    def index_files(self):
+    def add_files(self):
         """Index all files in the BIDS dataset. """
         self._index_dir(self.root, self.config)
 
-    def index_metadata(self, **filters):
+    def add_metadata(self, **filters):
         """Index metadata for all files in the BIDS dataset.
 
         Parameters

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -28,7 +28,7 @@ from ..exceptions import (
 from .writing import build_path, write_to_file
 from .models import (Base, Config, BIDSFile, Entity, Tag)
 from .index import BIDSLayoutIndexer
-from .db import ConnectionManager
+from .db import ConnectionManager, get_database_sidecar
 from .utils import (BIDSMetadata, parse_file_entities, add_config_paths,
                     _sanitize_init_args)
 
@@ -391,12 +391,12 @@ class BIDSLayout(object):
 
         Parameters
         ----------
-        database_path : str
+        database_path : str, Path
             The path to the desired database folder. By default,
             uses .db_cache. If a relative path is passed, it is assumed to
             be relative to the BIDSLayout root directory.
         """
-        database_file, database_sidecar = cls._make_db_paths(database_path)
+        database_sidecar = get_database_sidecar(database_path)
         init_args = json.loads(database_sidecar.read_text())
 
         return cls(database_path=database_path, **init_args)

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -190,7 +190,7 @@ class BIDSLayout(object):
 
         # Index project if needed
         self.indexer = BIDSLayoutIndexer(self)
-        if reset_database or self.connection_manager.database_file is None:
+        if self.connection_manager._database_reset:
             self.indexer.add_files()
             if index_metadata:
                 self.indexer.add_metadata()

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -1377,7 +1377,7 @@ class BIDSLayout(object):
             Whether to copy each file as a symbolic link or a deep copy.
         root : str
             Optional root directory that all patterns are relative
-            to. Defaults to current working directory.
+            to. Defaults to dataset root.
         conflicts : str
             Defines the desired action when the output path already exists.
             Must be one of:
@@ -1388,13 +1388,15 @@ class BIDSLayout(object):
         kwargs : dict
             Optional key word arguments to pass into a get() query.
         """
+        root = self.root if root is None else root
+
         _files = self.get(**kwargs)
         if files:
             _files = list(set(files).intersection(_files))
 
         for f in _files:
             f.copy(path_patterns, symbolic_link=symbolic_links,
-                   root=self.root, conflicts=conflicts)
+                   root=root, conflicts=conflicts)
 
     def write_to_file(self, entities, path_patterns=None,
                       contents=None, link_to=None, copy_from=None,

--- a/bids/layout/tests/conftest.py
+++ b/bids/layout/tests/conftest.py
@@ -1,7 +1,7 @@
 from os.path import join
 
 import pytest
-import tempfile
+
 from bids.layout import BIDSLayout
 from bids.tests import get_test_data_path
 

--- a/bids/layout/tests/test_db.py
+++ b/bids/layout/tests/test_db.py
@@ -1,0 +1,2 @@
+"""Test functionality in the db module--mostly related to connection
+management."""

--- a/bids/layout/tests/test_db.py
+++ b/bids/layout/tests/test_db.py
@@ -1,2 +1,18 @@
 """Test functionality in the db module--mostly related to connection
 management."""
+
+import re
+from pathlib import Path
+
+from bids.layout.db import (ConnectionManager, get_database_file,
+                            get_database_sidecar, _sanitize_init_args)
+
+
+def test_sanitize_init_args():
+    patt = [re.compile('f1ct.*n'), 'code']
+    root = Path('.') / 'fictional_path'
+    result = _sanitize_init_args(ignore=patt, root=root, absolute_paths=False)
+    assert result['absolute_paths'] == False
+    assert isinstance(result['ignore'], list)
+    assert all([isinstance(el, str) for el in result['ignore']])
+    assert isinstance(result['root'], str)

--- a/bids/layout/tests/test_db.py
+++ b/bids/layout/tests/test_db.py
@@ -16,3 +16,21 @@ def test_sanitize_init_args():
     assert isinstance(result['ignore'], list)
     assert all([isinstance(el, str) for el in result['ignore']])
     assert isinstance(result['root'], str)
+
+
+def test_get_database_file(tmp_path):
+    assert get_database_file(None) is None
+    new_path = tmp_path / "a_new_subdir"
+    assert not new_path.exists()
+    db_file = get_database_file(new_path)
+    assert db_file == new_path / 'layout_index.sqlite'
+    assert new_path.exists()
+
+
+def test_get_database_sidecar():
+    db_file = '/abs/path/to/db/file.sqlite'
+    f1 = get_database_sidecar(db_file)
+    assert isinstance(f1, Path)
+    assert str(f1) == '/abs/path/to/db/layout_args.json'
+    f2 = get_database_sidecar(Path(db_file))
+    assert f1 == f2

--- a/bids/layout/tests/test_db.py
+++ b/bids/layout/tests/test_db.py
@@ -19,6 +19,7 @@ def test_sanitize_init_args():
 
 
 def test_get_database_file(tmp_path):
+    tmp_path = Path(str(tmp_path))  # PY35: pytest uses pathlib2.Path; __fspath__ in Python 3.6 fixes this
     assert get_database_file(None) is None
     new_path = tmp_path / "a_new_subdir"
     assert not new_path.exists()

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -648,7 +648,6 @@ def test_indexing_tag_conflict():
     data_dir = join(get_test_data_path(), 'ds005_conflict')
     with pytest.raises(BIDSValidationError) as exc:
         layout = BIDSLayout(data_dir)
-        print(exc.value.message)
         assert exc.value.message.startswith("Conflicting values found")
         assert 'run' in exc.value.message
 

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -3,22 +3,19 @@ BIDSLayout class."""
 
 import os
 import re
-from os.path import join, abspath, basename, dirname
+from os.path import join, abspath, basename
 
 import numpy as np
 import pytest
 
-import bids
-from bids.layout import (BIDSLayout, parse_file_entities, add_config_paths,
-                         Query)
+from bids.layout import BIDSLayout, Query
 from bids.layout.index import BIDSLayoutIndexer
-from bids.layout.models import Entity, Config
+from bids.layout.models import Config
 from bids.tests import get_test_data_path
 from bids.utils import natural_sort
 
 from bids.exceptions import (
     BIDSValidationError,
-    ConfigError,
     NoMatchError,
     TargetError,
 )
@@ -487,38 +484,6 @@ def test_to_df(layout_ds117):
                 set(df.columns))
 
 
-@pytest.mark.parametrize("extension_initial_dot", (True, False))
-def test_parse_file_entities(mock_config, extension_initial_dot):
-    filename = '/sub-03_ses-07_run-4_desc-bleargh_sekret.nii.gz'
-
-    dot = '.' if extension_initial_dot else ''
-
-    # Test with entities taken from bids config
-    target = {'subject': '03', 'session': '07', 'run': 4, 'suffix': 'sekret',
-              'extension': dot + 'nii.gz'}
-    assert target == parse_file_entities(filename, config='bids')
-    config = Config.load('bids')
-    assert target == parse_file_entities(filename, config=[config])
-
-    # Test with entities taken from bids and derivatives config
-    target = {'subject': '03', 'session': '07', 'run': 4, 'suffix': 'sekret',
-              'desc': 'bleargh', 'extension': dot + 'nii.gz'}
-    assert target == parse_file_entities(filename)
-    assert target == parse_file_entities(
-        filename, config=['bids', 'derivatives'])
-
-    # Test with list of Entities
-    entities = [
-        Entity('subject', "[/\\\\]sub-([a-zA-Z0-9]+)"),
-        Entity('run', "[_/\\\\]run-0*(\\d+)", dtype=int),
-        Entity('suffix', "[._]*([a-zA-Z0-9]*?)\\.[^/\\\\]+$"),
-        Entity('desc', "desc-([a-zA-Z0-9]+)"),
-    ]
-    # Leave out session to distinguish from previous test target
-    target = {'subject': '03', 'run': 4, 'suffix': 'sekret', 'desc': 'bleargh'}
-    assert target == parse_file_entities(filename, entities=entities)
-
-
 # XXX 0.14: Add dot to extension (difficult to parametrize with module-scoped fixture)
 def test_parse_file_entities_from_layout(layout_synthetic):
     layout = layout_synthetic
@@ -559,20 +524,6 @@ def test_deriv_indexing():
     assert layout.get(scope='derivatives')
     assert layout.get(scope='events')
     assert not layout.get(scope='nonexistent')
-
-
-def test_add_config_paths():
-    bids_dir = dirname(bids.__file__)
-    bids_json = os.path.join(bids_dir, 'layout', 'config', 'bids.json')
-    with pytest.raises(ConfigError) as exc:
-        add_config_paths(test_config1='nonexistentpath.json')
-    assert str(exc.value).startswith('Configuration file')
-    with pytest.raises(ConfigError) as exc:
-        add_config_paths(bids=bids_json)
-    assert str(exc.value).startswith("Configuration 'bids' already")
-    add_config_paths(dummy=bids_json)
-    config = Config.load('dummy')
-    assert 'subject' in config.entities
 
 
 def test_layout_in_scope(layout_ds005, layout_ds005_derivs):

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -3,7 +3,7 @@ BIDSLayout class."""
 
 import os
 import re
-from os.path import join, abspath, basename
+from os.path import (join, abspath, basename)
 
 import numpy as np
 import pytest

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -3,7 +3,6 @@ functionality should go in the grabbit package. """
 
 import os
 import re
-import tempfile
 from os.path import join, abspath, basename, dirname
 
 import numpy as np
@@ -14,7 +13,6 @@ from bids.layout import (BIDSLayout, parse_file_entities, add_config_paths,
                          Query)
 from bids.layout.index import BIDSLayoutIndexer
 from bids.layout.models import Entity, Config
-from bids.layout.utils import BIDSMetadata
 from bids.tests import get_test_data_path
 from bids.utils import natural_sort
 
@@ -47,7 +45,7 @@ def test_index_metadata(index_metadata, query, result, mock_config):
     layout = BIDSLayout(data_dir, index_metadata=index_metadata)
     if not index_metadata and query is not None:
         indexer = BIDSLayoutIndexer(layout)
-        indexer.index_metadata(**query)
+        indexer.add_metadata(**query)
     sample_file = layout.get(task='rest', extension='.nii.gz',
                              acquisition='fullbrain')[0]
     metadata = sample_file.get_metadata()

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -1,5 +1,5 @@
-""" Tests of BIDS-specific functionality. Generic tests of core grabbit
-functionality should go in the grabbit package. """
+""" Tests of functionality in the layout module--mostly related to the
+BIDSLayout class."""
 
 import os
 import re

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -638,7 +638,7 @@ def test_layout_save(tmp_path, layout_7t_trt):
     layout_7t_trt.save(str(tmp_path / "f.sqlite"),
                        replace_connection=False)
     data_dir = join(get_test_data_path(), '7t_trt')
-    layout = BIDSLayout(data_dir, database_path=str(tmp_path))
+    layout = BIDSLayout(data_dir, database_path=str(tmp_path / "f.sqlite"))
     oldfies = set(layout_7t_trt.get(suffix='events', return_type='file'))
     newfies = set(layout.get(suffix='events', return_type='file'))
     assert oldfies == newfies

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -274,6 +274,17 @@ def test_get_return_type_dir(layout_7t_trt, layout_7t_trt_relpath):
     assert target == res2
 
 
+def test_ensure_non_detaching_sessions(layout_7t_trt, layout_7t_trt_relpath):
+    """ Ensure that sessions don't detach unexpectly during queries."""
+    query = dict(target='subject', return_type='dir')
+    res_relpath = layout_7t_trt_relpath.get(**query)
+    target_relpath = ["sub-{:02d}".format(i) for i in range(1, 11)]
+    assert target_relpath == res_relpath
+    res_abspath = layout_7t_trt.get(**query)
+    # Second query would break without expire_on_commit=True
+    res_relpath = layout_7t_trt_relpath.get(**query)
+
+
 @pytest.mark.parametrize("acq", [None, Query.NONE])
 def test_get_val_none(layout_7t_trt, acq):
     t1w_files = layout_7t_trt.get(subject='01', session='1', suffix='T1w')

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -723,4 +723,6 @@ def test_load_layout(layout_synthetic_nodb, db_dir):
     reloaded = BIDSLayout.load(db_path)
     assert sorted(layout_synthetic_nodb.get(return_type='file')) == \
         sorted(reloaded.get(return_type='file'))
-    assert layout_synthetic_nodb._init_args == reloaded._init_args
+    cm1 = layout_synthetic_nodb.connection_manager
+    cm2 = reloaded.connection_manager
+    assert cm1.init_args == cm2.init_args

--- a/bids/layout/tests/test_models.py
+++ b/bids/layout/tests/test_models.py
@@ -3,7 +3,6 @@
 import sys
 import os
 import pytest
-import bids
 import copy
 import json
 from pathlib import Path
@@ -14,7 +13,6 @@ import numpy as np
 
 from bids.layout.models import (BIDSFile, Entity, Tag, Base, Config,
                                 FileAssociation, BIDSImageFile)
-from bids.layout import BIDSLayout
 from bids.tests import get_test_data_path
 
 

--- a/bids/layout/tests/test_models.py
+++ b/bids/layout/tests/test_models.py
@@ -1,3 +1,5 @@
+"""Tests of functionality in the models module."""
+
 import sys
 import os
 import pytest

--- a/bids/layout/tests/test_path_building.py
+++ b/bids/layout/tests/test_path_building.py
@@ -1,9 +1,10 @@
 """Tests of path-building functionality."""
 
+from os.path import join
+from pathlib import Path
+
 import pytest
 from bids.layout import BIDSLayout
-from os.path import join, abspath, sep
-from pathlib import Path
 from bids.tests import get_test_data_path
 
 

--- a/bids/layout/tests/test_path_building.py
+++ b/bids/layout/tests/test_path_building.py
@@ -1,3 +1,5 @@
+"""Tests of path-building functionality."""
+
 import pytest
 from bids.layout import BIDSLayout
 from os.path import join, abspath, sep

--- a/bids/layout/tests/test_rootpath.py
+++ b/bids/layout/tests/test_rootpath.py
@@ -5,6 +5,7 @@ Test handling of pathlib Path file paths in place of old-style string type.
 import sys
 import pytest
 from pathlib import Path
+
 from bids.layout import BIDSLayout
 from bids.tests import get_test_data_path
 

--- a/bids/layout/tests/test_rootpath.py
+++ b/bids/layout/tests/test_rootpath.py
@@ -1,11 +1,13 @@
+"""
+Test handling of pathlib Path file paths in place of old-style string type.
+"""
+
 import sys
 import pytest
 from pathlib import Path
 from bids.layout import BIDSLayout
 from bids.tests import get_test_data_path
-"""
-test handling of pathlib Path file paths in place of old-style string type
-"""
+
 
 TESTPATH = Path(get_test_data_path()).joinpath("ds005")
 TESTSTR = str(TESTPATH)

--- a/bids/layout/tests/test_utils.py
+++ b/bids/layout/tests/test_utils.py
@@ -1,7 +1,13 @@
 """Test miscellaneous utilities."""
 
+import os
+
 import pytest
-from ..utils import BIDSMetadata
+import bids
+from bids.exceptions import ConfigError
+
+from ..models import Entity, Config
+from ..utils import BIDSMetadata, parse_file_entities, add_config_paths
 
 
 def test_bidsmetadata_class():
@@ -11,3 +17,49 @@ def test_bidsmetadata_class():
     assert "Metadata term 'Missing' unavailable for file fakefile." in str(err)
     md["Missing"] = 1
     assert md["Missing"] == 1
+
+
+@pytest.mark.parametrize("extension_initial_dot", (True, False))
+def test_parse_file_entities(mock_config, extension_initial_dot):
+    filename = '/sub-03_ses-07_run-4_desc-bleargh_sekret.nii.gz'
+
+    dot = '.' if extension_initial_dot else ''
+
+    # Test with entities taken from bids config
+    target = {'subject': '03', 'session': '07', 'run': 4, 'suffix': 'sekret',
+              'extension': dot + 'nii.gz'}
+    assert target == parse_file_entities(filename, config='bids')
+    config = Config.load('bids')
+    assert target == parse_file_entities(filename, config=[config])
+
+    # Test with entities taken from bids and derivatives config
+    target = {'subject': '03', 'session': '07', 'run': 4, 'suffix': 'sekret',
+              'desc': 'bleargh', 'extension': dot + 'nii.gz'}
+    assert target == parse_file_entities(filename)
+    assert target == parse_file_entities(
+        filename, config=['bids', 'derivatives'])
+
+    # Test with list of Entities
+    entities = [
+        Entity('subject', "[/\\\\]sub-([a-zA-Z0-9]+)"),
+        Entity('run', "[_/\\\\]run-0*(\\d+)", dtype=int),
+        Entity('suffix', "[._]*([a-zA-Z0-9]*?)\\.[^/\\\\]+$"),
+        Entity('desc', "desc-([a-zA-Z0-9]+)"),
+    ]
+    # Leave out session to distinguish from previous test target
+    target = {'subject': '03', 'run': 4, 'suffix': 'sekret', 'desc': 'bleargh'}
+    assert target == parse_file_entities(filename, entities=entities)
+
+
+def test_add_config_paths():
+    bids_dir = os.path.dirname(bids.__file__)
+    bids_json = os.path.join(bids_dir, 'layout', 'config', 'bids.json')
+    with pytest.raises(ConfigError) as exc:
+        add_config_paths(test_config1='nonexistentpath.json')
+    assert str(exc.value).startswith('Configuration file')
+    with pytest.raises(ConfigError) as exc:
+        add_config_paths(bids=bids_json)
+    assert str(exc.value).startswith("Configuration 'bids' already")
+    add_config_paths(dummy=bids_json)
+    config = Config.load('dummy')
+    assert 'subject' in config.entities

--- a/bids/layout/tests/test_utils.py
+++ b/bids/layout/tests/test_utils.py
@@ -1,3 +1,5 @@
+"""Test miscellaneous utilities."""
+
 import pytest
 from ..utils import BIDSMetadata
 

--- a/bids/layout/tests/test_validation.py
+++ b/bids/layout/tests/test_validation.py
@@ -1,5 +1,4 @@
-""" Tests of BIDS-specific functionality. Generic tests of core grabbit
-functionality should go in the grabbit package. """
+"""Tests of BIDSValidator functionality."""
 
 import pytest
 from bids_validator import BIDSValidator

--- a/bids/layout/tests/test_validation.py
+++ b/bids/layout/tests/test_validation.py
@@ -1,9 +1,11 @@
 """Tests of BIDSValidator functionality."""
 
+from os.path import join, dirname, abspath
+
 import pytest
+
 from bids_validator import BIDSValidator
 from bids.layout import BIDSLayout
-from os.path import join, dirname, abspath
 from bids.tests import get_test_data_path
 
 

--- a/bids/layout/tests/test_writing.py
+++ b/bids/layout/tests/test_writing.py
@@ -1,3 +1,5 @@
+"""Tests related to file-writing functionality."""
+
 import pytest
 import os
 import shutil

--- a/bids/layout/tests/test_writing.py
+++ b/bids/layout/tests/test_writing.py
@@ -1,17 +1,17 @@
 """Tests related to file-writing functionality."""
 
-import pytest
-import os
 import shutil
+import os
 from os.path import join, exists, islink, dirname
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
 from bids.layout.writing import build_path, _PATTERN_FIND
 from bids.tests import get_test_data_path
 from bids import BIDSLayout
 from bids.layout.models import BIDSFile, Entity, Tag, Base
-
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
 
 
 @pytest.fixture

--- a/bids/layout/utils.py
+++ b/bids/layout/utils.py
@@ -1,3 +1,12 @@
+"""Miscellaneous layout-related utilities."""
+import os
+from pathlib import Path
+
+from .. import config as cf
+from ..utils import make_bidsfile, listify
+from ..exceptions import ConfigError
+
+
 class BIDSMetadata(dict):
     """ Metadata dictionary that reports the associated file on lookup failures. """
     def __init__(self, source_file):
@@ -10,3 +19,102 @@ class BIDSMetadata(dict):
         except KeyError as e:
             raise KeyError(
                 "Metadata term {!r} unavailable for file {}.".format(key, self._source_file))
+
+
+def parse_file_entities(filename, entities=None, config=None,
+                        include_unmatched=False):
+    """Parse the passed filename for entity/value pairs.
+
+    Parameters
+    ----------
+    filename : str
+        The filename to parse for entity values
+    entities : list or None, optional
+        An optional list of Entity instances to use in extraction.
+        If passed, the config argument is ignored. Default is None.
+    config : str or :obj:`bids.layout.models.Config` or list or None, optional
+        One or more :obj:`bids.layout.models.Config` objects or names of
+        configurations to use in matching. Each element must be a
+        :obj:`bids.layout.models.Config` object, or a valid
+        :obj:`bids.layout.models.Config` name (e.g., 'bids' or 'derivatives').
+        If None, all available configs are used. Default is None.
+    include_unmatched : bool, optional
+        If True, unmatched entities are included in the returned dict,
+        with values set to None.
+        If False (default), unmatched entities are ignored.
+
+    Returns
+    -------
+    dict
+        Keys are Entity names and values are the values from the filename.
+    """
+    # Load Configs if needed
+    if entities is None:
+
+        if config is None:
+            config = ['bids', 'derivatives']
+
+        from .models import Config
+        config = [Config.load(c) if not isinstance(c, Config) else c
+                  for c in listify(config)]
+
+        # Consolidate entities from all Configs into a single dict
+        entities = {}
+        for c in config:
+            entities.update(c.entities)
+        entities = entities.values()
+
+    # Extract matches
+    bf = make_bidsfile(filename)
+    ent_vals = {}
+    for ent in entities:
+        match = ent.match_file(bf)
+        if match is not None or include_unmatched:
+            ent_vals[ent.name] = match
+
+    return ent_vals
+
+
+def add_config_paths(**kwargs):
+    """Add to the pool of available configuration files for BIDSLayout.
+
+    Parameters
+    ----------
+    kwargs : dict
+        Dictionary specifying where to find additional config files.
+        Keys are names, values are paths to the corresponding .json file.
+
+    Examples
+    --------
+    > add_config_paths(my_config='/path/to/config')
+    > layout = BIDSLayout('/path/to/bids', config=['bids', 'my_config'])
+    """
+    for k, path in kwargs.items():
+        if not os.path.exists(path):
+            raise ConfigError(
+                'Configuration file "{}" does not exist'.format(k))
+        if k in cf.get_option('config_paths'):
+            raise ConfigError('Configuration {!r} already exists'.format(k))
+
+    kwargs.update(**cf.get_option('config_paths'))
+    cf.set_option('config_paths', kwargs)
+
+
+def _sanitize_init_args(**kwargs):
+    """ Prepare initalization arguments for serialization """
+    # Make ignore and force_index serializable
+    for k in ['ignore', 'force_index']:
+        kwargs[k] = [
+            str(a) for a in kwargs[k] if a is not None] \
+            if kwargs[k] is not None else None
+
+    kwargs['root'] = str(Path(kwargs['root']).absolute())
+
+    # Get abspaths
+    if isinstance(kwargs['derivatives'], list):
+        kwargs['derivatives'] = [
+            str(Path(der).absolute())
+            for der in listify(kwargs['derivatives'])
+            ]
+
+    return kwargs

--- a/bids/layout/utils.py
+++ b/bids/layout/utils.py
@@ -98,23 +98,3 @@ def add_config_paths(**kwargs):
 
     kwargs.update(**cf.get_option('config_paths'))
     cf.set_option('config_paths', kwargs)
-
-
-def _sanitize_init_args(**kwargs):
-    """ Prepare initalization arguments for serialization """
-    # Make ignore and force_index serializable
-    for k in ['ignore', 'force_index']:
-        kwargs[k] = [
-            str(a) for a in kwargs[k] if a is not None] \
-            if kwargs[k] is not None else None
-
-    kwargs['root'] = str(Path(kwargs['root']).absolute())
-
-    # Get abspaths
-    if isinstance(kwargs['derivatives'], list):
-        kwargs['derivatives'] = [
-            str(Path(der).absolute())
-            for der in listify(kwargs['derivatives'])
-            ]
-
-    return kwargs


### PR DESCRIPTION
Reorganizes a lot of the functionality in `BIDLayout`:

* Most database-related functionality is now in a `ConnectionManager` class in a new `db` module.
* Also pushed setup of the `Config` objects into the `ConnectionManager` class.
* Moved some utilities out of `layout.py` and into `utils.py`.
* Made some static class methods functions to keep the `BIDSLayout` class more manageable.
* Streamlined the logic in the `BIDSLayout` init; should now be much easier to follow.

Cleaning up the session management seems to have magically resolved the problems in #533/#616/#625/#630, which was what originally motivated this PR—so that's a happy ending.

Closes #533.