### PR TITLE
FIX: Convolve zero-duration (impulse) events when variable contains multiple events

### DIFF
--- a/bids/analysis/tests/test_transformations.py
+++ b/bids/analysis/tests/test_transformations.py
@@ -93,6 +93,22 @@ def test_convolve(collection):
             oversampling=2.0)
 
 
+def test_convolve_impulse():
+    # Smoke test impulse convolution
+    data = pd.DataFrame({
+        'onset': [10, 20],
+        'duration': [0, 0],
+        'amplitude': [1, 1]
+    })
+    run_info = [RunInfo({'subject': '01'}, 20, 2, 'dummy.nii.gz')]
+    var = SparseRunVariable(
+        name='var', data=data, run_info=run_info, source='events')
+    coll = BIDSRunVariableCollection([var])
+    transform.ToDense(coll, 'var', output='var_dense')
+    transform.Convolve(coll, 'var', output='var_hrf')
+    transform.Convolve(coll, 'var_dense', output='var_dense_hrf')
+
+
 def test_rename(collection):
     dense_rt = collection.variables['RT'].to_dense(collection.sampling_rate)
     assert len(dense_rt.values) == math.ceil(len(SUBJECTS) * NRUNS * SCAN_LENGTH * collection.sampling_rate)

--- a/bids/analysis/tests/test_transformations.py
+++ b/bids/analysis/tests/test_transformations.py
@@ -77,20 +77,20 @@ def test_convolve(collection):
         transform.Convolve(collection, 'RT', output='rt_mock')
         mocked.compute_regressor.assert_called_with(
             mock.ANY, 'spm', mock.ANY, fir_delays=None, min_onset=0,
-            oversampling=1.0)
+            oversampling=2.0)
 
     with mock.patch('bids.analysis.transformations.compute.hrf') as mocked:
         transform.Convolve(collection, 'rt_dense', output='rt_mock')
         mocked.compute_regressor.assert_called_with(
             mock.ANY, 'spm', mock.ANY, fir_delays=None, min_onset=0,
-            oversampling=3.0)
+            oversampling=2.0)
 
     with mock.patch('bids.analysis.transformations.compute.hrf') as mocked:
         collection.sampling_rate = 0.5
         transform.Convolve(collection, 'RT', output='rt_mock')
         mocked.compute_regressor.assert_called_with(
             mock.ANY, 'spm', mock.ANY, fir_delays=None, min_onset=0,
-            oversampling=2.0)
+            oversampling=4.0)
 
 
 def test_convolve_impulse():


### PR DESCRIPTION
Fixing #643.

Starting with a test.

To bring some context over, convolving a single, zero-duration event produces expected results. If a second event is present, zero duration or otherwise, then the logic currently uses the minimum duration to estimate a reasonable oversampling rate. When duration is 0, the rate is infinite, and problems are had.