### PR TITLE
ENH: Add relpath attribute to BIDSFile and associated refactoring

### DIFF
--- a/bids/__init__.py
+++ b/bids/__init__.py
@@ -1,5 +1,5 @@
 from .due import due, Doi
-from .layout import BIDSLayout
+from .layout import BIDSLayout, BIDSLayoutIndexer
 
 # For backwards compatibility
 from bids_validator import BIDSValidator
@@ -7,13 +7,13 @@ from bids_validator import BIDSValidator
 __all__ = [
     "analysis",
     "BIDSLayout",
+    "BIDSLayoutIndexer",
     "BIDSValidator",
     "config",
     "layout",
     "reports",
     "utils",
     "variables"
-
 ]
 
 due.cite(Doi("10.1038/sdata.2016.44"),

--- a/bids/layout/__init__.py
+++ b/bids/layout/__init__.py
@@ -1,12 +1,14 @@
 from .layout import BIDSLayout, Query
 from .models import (BIDSFile, BIDSImageFile, BIDSDataFile, BIDSJSONFile,
                      Config, Entity, Tag)
+from .index import BIDSLayoutIndexer
 from .utils import add_config_paths, parse_file_entities
 # Backwards compatibility
 from bids_validator import BIDSValidator
 
 __all__ = [
     "BIDSLayout",
+    "BIDSLayoutIndexer",
     "BIDSValidator",
     "add_config_paths",
     "parse_file_entities",

--- a/bids/layout/db.py
+++ b/bids/layout/db.py
@@ -46,8 +46,6 @@ class ConnectionManager:
 
         if reset_database:
             self.reset_database(init_args, config)
-        else:
-            self.load_database()
 
         self._database_reset = reset_database
 
@@ -114,11 +112,6 @@ class ConnectionManager:
         config = [Config.load(c, session=self.session) for c in listify(config)]
         self.session.add_all(config)
         self.session.commit()
-
-    def load_database(self):
-        if self.database_file is None:
-            raise ValueError("load_database() can only be called on databases "
-                             "stored in a file, not on in-memory databases.")
 
     def save_database(self, database_path, replace_connection=True):
         """Save the current index as a SQLite3 DB at the specified location.

--- a/bids/layout/db.py
+++ b/bids/layout/db.py
@@ -37,26 +37,6 @@ def get_database_sidecar(path):
     return path.parent / 'layout_args.json'
 
 
-def _sanitize_init_args(**kwargs):
-    """ Prepare initalization arguments for serialization """
-    # Make ignore and force_index serializable
-    for k in ['ignore', 'force_index']:
-        if kwargs.get(k) is not None:
-            kwargs[k] = [str(a) for a in kwargs.get(k) if a is not None]
-
-    if 'root' in kwargs:
-        kwargs['root'] = str(Path(kwargs['root']).absolute())
-
-    # Get abspaths
-    if 'derivatives' in kwargs and isinstance(kwargs['derivatives'], list):
-        kwargs['derivatives'] = [
-            str(Path(der).absolute())
-            for der in listify(kwargs['derivatives'])
-            ]
-
-    return kwargs
-
-
 class ConnectionManager:
 
     def __init__(self, database_path=None, reset_database=False, config=None,

--- a/bids/layout/index.py
+++ b/bids/layout/index.py
@@ -43,36 +43,54 @@ def _check_path_matches_patterns(path, patterns):
 class BIDSLayoutIndexer(object):
     """ Indexer class for BIDSLayout.
 
-    Args:
-        layout (BIDSLayout): The BIDSLayout to index.
+    Parameters
+    ----------
+    ignore : str or SRE_Pattern or list
+        Path(s) to exclude from indexing. Each path is either a string or a
+        SRE_Pattern object (i.e., compiled regular expression). If a string is
+        passed, it must be either an absolute path, or be relative to the BIDS
+        project root. If an SRE_Pattern is passed, the contained regular
+        expression will be matched against the full (absolute) path of all
+        files and directories. By default, indexing ignores all files in
+        'code/', 'stimuli/', 'sourcedata/', 'models/', and any hidden
+        files/dirs beginning with '.' at root level.
+    force_index : str or SRE_Pattern or list
+        Path(s) to forcibly index in the BIDSLayout, even if they would
+        otherwise fail validation. See the documentation for the ignore
+        argument for input format details. Note that paths in force_index takes
+        precedence over those in ignore (i.e., if a file matches both ignore
+        and force_index, it *will* be indexed).
+        Note: NEVER include 'derivatives' here; use the derivatives argument
+        (or :obj:`bids.layout.BIDSLayout.add_derivatives`) for that.
+    index_metadata : bool
+        If True, all metadata files are indexed at initialization. If False,
+        metadata will not be available (but indexing will be faster).
     """
 
-    def __init__(self, layout, ignore=None, force_index=None):
-
-        self.layout = layout
-        self.config = list(layout.config.values())
-        self.session = layout.session
-        self.validate = layout.validate
-        self.root = layout.root
-        self.config_filename = layout.config_filename
+    def __init__(self, ignore=None, force_index=None, index_metadata=True):
         self.validator = BIDSValidator(index_associated=True)
+        self.index_metadata = index_metadata
+        self.ignore = ignore
+        self.force_index = force_index
 
-        ignore, force = validate_indexing_args(ignore, force_index, self.root)
-        self.include_patterns = force
-        self.exclude_patterns = ignore
+        # Layout-dependent attributes to be set in index()
+        self._layout = None
+        self._config = None
+        self._include_patterns = None
+        self._exclude_patterns = None
 
     def _validate_dir(self, d, default=None):
-        if _check_path_matches_patterns(d, self.include_patterns):
+        if _check_path_matches_patterns(d, self._include_patterns):
             return True
-        if _check_path_matches_patterns(d, self.exclude_patterns):
+        if _check_path_matches_patterns(d, self._exclude_patterns):
             return False
         return default
 
     def _validate_file(self, f, default=None):
         # Inclusion takes priority over exclusion
-        if _check_path_matches_patterns(f, self.include_patterns):
+        if _check_path_matches_patterns(f, self._include_patterns):
             return True
-        if _check_path_matches_patterns(f, self.exclude_patterns):
+        if _check_path_matches_patterns(f, self._exclude_patterns):
             return False
 
         # If inclusion/exclusion is inherited from a parent directory, that
@@ -82,29 +100,29 @@ class BIDSLayoutIndexer(object):
 
         # Derivatives are currently not validated.
         # TODO: raise warning the first time in a session this is encountered
-        if not self.validate or 'derivatives' in self.layout.config:
+        if not self._layout.validate or 'derivatives' in self._layout.config:
             return True
 
         # BIDS validator expects absolute paths, but really these are relative
         # to the BIDS project root.
-        to_check = os.path.relpath(f, self.root)
+        to_check = os.path.relpath(f, self._layout.root)
         to_check = os.path.join(os.path.sep, to_check)
         to_check = Path(to_check).as_posix()  # bids-validator works with posix paths only
         return self.validator.is_bids(to_check)
 
     def _index_dir(self, path, config, default_action=None):
 
-        abs_path = os.path.join(self.root, path)
+        abs_path = os.path.join(self._layout.root, path)
 
         # Derivative directories must always be added separately
         # and passed as their own root, so terminate if passed.
-        if abs_path.startswith(os.path.join(self.root, 'derivatives')):
+        if abs_path.startswith(os.path.join(self._layout.root, 'derivatives')):
             return
 
         config = list(config)  # Shallow copy
 
         # Check for additional config file in directory
-        layout_file = self.config_filename
+        layout_file = self._layout.config_filename
         config_file = os.path.join(abs_path, layout_file)
         if os.path.exists(config_file):
             cfg = Config.load(config_file, session=self.session)
@@ -121,8 +139,8 @@ class BIDSLayoutIndexer(object):
             default = self._validate_dir(dirpath, default=default_action)
 
             # If layout configuration file exists, delete it
-            if self.config_filename in filenames:
-                filenames.remove(self.config_filename)
+            if self._layout.config_filename in filenames:
+                filenames.remove(self._layout.config_filename)
 
             for f in filenames:
 
@@ -169,9 +187,27 @@ class BIDSLayoutIndexer(object):
 
         return bf
 
+    @property
+    def session(self):
+        return self._layout.session
+
+    def index(self, layout):
+
+        self._layout = layout
+        self._config = list(layout.config.values())
+
+        ignore, force = validate_indexing_args(self.ignore, self.force_index,
+                                               self._layout.root)
+        self._include_patterns = force
+        self._exclude_patterns = ignore
+
+        self.add_files()
+        if self.index_metadata:
+            self.add_metadata()
+
     def add_files(self):
         """Index all files in the BIDS dataset. """
-        self._index_dir(self.root, self.config)
+        self._index_dir(self._layout.root, self._config)
 
     def add_metadata(self, **filters):
         """Index metadata for all files in the BIDS dataset.
@@ -202,11 +238,11 @@ class BIDSLayoutIndexer(object):
                     filters[ext_key].append(json_ext)
 
         # Process JSON files first if we're indexing metadata
-        all_files = self.layout.get(absolute_paths=True, **filters)
+        all_files = self._layout.get(absolute_paths=True, **filters)
 
         # Track ALL entities we've seen in file names or metadatas
         all_entities = {}
-        for c in self.config:
+        for c in self._config:
             all_entities.update(c.entities)
 
         # If key/value pairs in JSON files duplicate ones extracted from files,
@@ -346,13 +382,14 @@ class BIDSLayoutIndexer(object):
             for target in intended:
                 # Per spec, IntendedFor paths are relative to sub dir.
                 target = os.path.join(
-                    self.root, 'sub-{}'.format(bf.entities['subject']), target)
+                    self._layout.root, 'sub-{}'.format(bf.entities['subject']),
+                    target)
                 create_association_pair(bf.path, target, 'IntendedFor',
                                         'InformedBy')
 
             # Link files to BOLD runs
             if suffix in ['physio', 'stim', 'events', 'sbref']:
-                images = self.layout.get(
+                images = self._layout.get(
                     extension=['.nii', '.nii.gz'], suffix='bold',
                     return_type='filename', **file_ents)
                 for img in images:
@@ -361,7 +398,7 @@ class BIDSLayoutIndexer(object):
 
             # Link files to DWI runs
             if suffix == 'sbref' or ext in ['bvec', 'bval']:
-                images = self.layout.get(
+                images = self._layout.get(
                     extension=['.nii', '.nii.gz'], suffix='dwi',
                     return_type='filename', **file_ents)
                 for img in images:

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -150,11 +150,12 @@ class BIDSLayout(object):
         self.config = {c.name: c for c in self.session.query(Config).all()}
 
         if indexer is None:
-            indexer = BIDSLayoutIndexer(ignore, force_index, index_metadata,
-                                        config_filename)
+            indexer = BIDSLayoutIndexer(ignore, force_index, config_filename)
         self.indexer = indexer
         if self.connection_manager._database_reset:
-            self.indexer.index(self)
+            self.indexer.index_files(self)
+            if index_metadata:
+                self.indexer.index_metadata(self)
 
         # Add derivatives if any are found
         if derivatives:

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -112,7 +112,7 @@ class BIDSLayout(object):
                  regex_search=False, database_path=None, reset_database=False,
                  indexer=None, **indexer_kwargs):
 
-        if absolute_paths == False:
+        if not absolute_paths:
             absolute_path_deprecation_warning()
 
         ind_args = {'force_index', 'ignore', 'index_metadata', 'config_filename'}
@@ -587,7 +587,7 @@ class BIDSLayout(object):
             A list of BIDSFiles (default) or strings (see return_type).
         """
 
-        if absolute_paths == False:
+        if absolute_paths is False:
             absolute_path_deprecation_warning()
 
         layouts = self._get_layouts_in_scope(scope)

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -25,7 +25,8 @@ from ..exceptions import (
 )
 
 from .validation import (validate_root, validate_derivative_paths,
-                         absolute_path_deprecation_warning)
+                         absolute_path_deprecation_warning,
+                         indexer_arg_deprecation_warning)
 from .writing import build_path, write_to_file
 from .models import (Base, Config, BIDSFile, Entity, Tag)
 from .index import BIDSLayoutIndexer
@@ -101,9 +102,9 @@ class BIDSLayout(object):
         None, a new indexer with default parameters will be implicitly created.
     indexer_kwargs: dict
         Optional keyword arguments to pass onto the newly created
-        BIDSLayoutIndexer. Valid keywords are 'validate', 'ignore',
-        'force_index', 'index_metadata', and 'config_filename'. Ignored if
-        indexer is not None.
+        BIDSLayoutIndexer. Valid keywords are 'ignore', 'force_index',
+        'index_metadata', and 'config_filename'. Ignored if indexer is not
+        None.
     """
 
     def __init__(self, root=None, validate=True, absolute_paths=True,
@@ -113,6 +114,10 @@ class BIDSLayout(object):
 
         if absolute_paths == False:
             absolute_path_deprecation_warning()
+
+        ind_args = {'force_index', 'ignore', 'index_metadata', 'config_filename'}
+        if ind_args & set(indexer_kwargs.keys()):
+            indexer_arg_deprecation_warning()
 
         # Load from existing database file
         load_db = (database_path is not None and reset_database is False and

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -145,7 +145,7 @@ class BIDSLayout(object):
                 database_path, reset_database, config, init_args)
 
             if indexer is None:
-                indexer = BIDSLayoutIndexer(**indexer_kwargs)
+                indexer = BIDSLayoutIndexer(validate=validate, **indexer_kwargs)
             indexer(self)
 
         # Add derivatives if any are found

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -24,7 +24,8 @@ from ..exceptions import (
     TargetError,
 )
 
-from .validation import validate_root, validate_derivative_paths
+from .validation import (validate_root, validate_derivative_paths,
+                         absolute_path_deprecation_warning)
 from .writing import build_path, write_to_file
 from .models import (Base, Config, BIDSFile, Entity, Tag)
 from .index import BIDSLayoutIndexer
@@ -127,6 +128,9 @@ class BIDSLayout(object):
                  force_index=None, config_filename='layout_config.json',
                  regex_search=False, database_path=None, reset_database=False,
                  index_metadata=True, indexer=None):
+
+        if absolute_paths == False:
+            absolute_path_deprecation_warning()
 
         # Validate that a valid BIDS project exists at root
         root, description = validate_root(root, validate)
@@ -590,6 +594,9 @@ class BIDSLayout(object):
         list of :obj:`bids.layout.BIDSFile` or str
             A list of BIDSFiles (default) or strings (see return_type).
         """
+
+        if absolute_paths == False:
+            absolute_path_deprecation_warning()
 
         layouts = self._get_layouts_in_scope(scope)
 

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -138,7 +138,6 @@ class BIDSLayout(object):
         self.derivatives = {}
         self.sources = sources
         self.regex_search = regex_search
-        self.config_filename = config_filename
 
         init_args = dict(
             root=root, validate=validate, absolute_paths=absolute_paths,
@@ -151,7 +150,8 @@ class BIDSLayout(object):
         self.config = {c.name: c for c in self.session.query(Config).all()}
 
         if indexer is None:
-            indexer = BIDSLayoutIndexer(ignore, force_index, index_metadata)
+            indexer = BIDSLayoutIndexer(ignore, force_index, index_metadata,
+                                        config_filename)
         self.indexer = indexer
         if self.connection_manager._database_reset:
             self.indexer.index(self)

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -95,9 +95,10 @@ class BIDSLayout(object):
         in the root argument is reindexed. If False, indexing will be
         skipped and the existing database file will be used. Ignored if
         database_path is not provided.
-    indexer: BIDSLayoutIndexer
-        An optional BIDSLayoutIndexer to use for indexing. If None, a new
-        indexer with default parameters will be created.
+    indexer: BIDSLayoutIndexer or callable
+        An optional BIDSLayoutIndexer instance to use for indexing, or any
+        callable that takes a BIDSLayout instance as its only argument. If
+        None, a new indexer with default parameters will be implicitly created.
     indexer_kwargs: dict
         Optional keyword arguments to pass onto the newly created
         BIDSLayoutIndexer. Valid keywords are 'validate', 'ignore',

--- a/bids/layout/models.py
+++ b/bids/layout/models.py
@@ -7,6 +7,7 @@ import warnings
 import json
 from copy import deepcopy
 from itertools import chain
+from functools import lru_cache
 
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.associationproxy import association_proxy
@@ -231,6 +232,13 @@ class BIDSFile(Base):
 
     def __fspath__(self):
         return self.path
+
+    @property
+    @lru_cache()
+    def relpath(self):
+        """Return path relative to layout root"""
+        root = object_session(self).query(LayoutInfo).first().root
+        return str(Path(self.path).relative_to(root))
 
     def get_associations(self, kind=None, include_parents=False):
         """Get associated files, optionally limiting by association kind.

--- a/bids/layout/models.py
+++ b/bids/layout/models.py
@@ -28,19 +28,14 @@ class LayoutInfo(Base):
     __tablename__ = 'layout_info'
 
     root = Column(String, primary_key=True)
-    validate = Column(Boolean)
     absolute_paths = Column(Boolean)
-    index_metadata = Column(Boolean)
-
     _derivatives = Column(String)
-    _ignore = Column(String)
-    _force_index = Column(String)
     _config = Column(String)
 
     def __init__(self, **kwargs):
         init_args = self._sanitize_init_args(kwargs)
-        raw_cols = ['root', 'validate', 'absolute_paths', 'index_metadata']
-        json_cols = ['derivatives', 'ignore', 'force_index', 'config']
+        raw_cols = ['root', 'absolute_paths']
+        json_cols = ['derivatives', 'config']
         all_cols = raw_cols + json_cols
         missing_cols = set(all_cols) - set(init_args.keys())
         if missing_cols:
@@ -54,17 +49,12 @@ class LayoutInfo(Base):
 
     @reconstructor
     def _init_on_load(self):
-        for col in ['derivatives', 'ignore', 'force_index', 'config']:
+        for col in ['derivatives', 'config']:
             db_val = getattr(self, '_' + col)
             setattr(self, col, json.loads(db_val))
 
     def _sanitize_init_args(self, kwargs):
         """ Prepare initalization arguments for serialization """
-        # Make ignore and force_index serializable
-        for k in ['ignore', 'force_index']:
-            if kwargs.get(k) is not None:
-                kwargs[k] = [str(a) for a in kwargs.get(k) if a is not None]
-
         if 'root' in kwargs:
             kwargs['root'] = str(Path(kwargs['root']).absolute())
 

--- a/bids/layout/tests/test_db.py
+++ b/bids/layout/tests/test_db.py
@@ -4,18 +4,7 @@ management."""
 import re
 from pathlib import Path
 
-from bids.layout.db import (ConnectionManager, get_database_file,
-                            get_database_sidecar, _sanitize_init_args)
-
-
-def test_sanitize_init_args():
-    patt = [re.compile('f1ct.*n'), 'code']
-    root = Path('.') / 'fictional_path'
-    result = _sanitize_init_args(ignore=patt, root=root, absolute_paths=False)
-    assert result['absolute_paths'] == False
-    assert isinstance(result['ignore'], list)
-    assert all([isinstance(el, str) for el in result['ignore']])
-    assert isinstance(result['root'], str)
+from bids.layout.db import (ConnectionManager, get_database_file)
 
 
 def test_get_database_file(tmp_path):
@@ -26,12 +15,3 @@ def test_get_database_file(tmp_path):
     db_file = get_database_file(new_path)
     assert db_file == new_path / 'layout_index.sqlite'
     assert new_path.exists()
-
-
-def test_get_database_sidecar():
-    db_file = '/abs/path/to/db/file.sqlite'
-    f1 = get_database_sidecar(db_file)
-    assert isinstance(f1, Path)
-    assert str(f1) == '/abs/path/to/db/layout_args.json'
-    f2 = get_database_sidecar(Path(db_file))
-    assert f1 == f2

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -196,12 +196,12 @@ def test_get_metadata_error(layout_7t_trt):
 def test_get_with_bad_target(layout_7t_trt):
     with pytest.raises(TargetError) as exc:
         layout_7t_trt.get(target='unicorn')
-        msg = exc.value.message
-        assert 'subject' in msg and 'reconstruction' in msg and 'proc' in msg
+    msg = str(exc.value)
+    assert 'subject' in msg and 'reconstruction' in msg and 'proc' in msg
     with pytest.raises(TargetError) as exc:
         layout_7t_trt.get(target='sub')
-        msg = exc.value.message
-        assert 'subject' in msg and 'reconstruction' not in msg
+    msg = str(exc.value)
+    assert 'subject' in msg and 'reconstruction' not in msg
 
 
 def test_get_bvals_bvecs(layout_ds005):
@@ -455,11 +455,11 @@ def test_get_tr(layout_7t_trt):
     # Bad subject, should fail
     with pytest.raises(NoMatchError) as exc:
         layout_7t_trt.get_tr(subject="zzz")
-        assert exc.value.message.startswith("No functional images")
+    assert str(exc.value).startswith("No functional images")
     # There are multiple tasks with different TRs, so this should fail
     with pytest.raises(NoMatchError) as exc:
         layout_7t_trt.get_tr(subject=['01', '02'])
-        assert exc.value.message.startswith("Unique TR")
+    assert str(exc.value).startswith("Unique TR")
     # This should work
     tr = layout_7t_trt.get_tr(subject=['01', '02'], acquisition="fullbrain")
     assert tr == 3.0
@@ -598,8 +598,8 @@ def test_indexing_tag_conflict():
     data_dir = join(get_test_data_path(), 'ds005_conflict')
     with pytest.raises(BIDSValidationError) as exc:
         layout = BIDSLayout(data_dir)
-        assert exc.value.message.startswith("Conflicting values found")
-        assert 'run' in exc.value.message
+    assert str(exc.value).startswith("Conflicting values found")
+    assert 'run' in str(exc.value)
 
 
 def test_get_with_wrong_dtypes(layout_7t_trt):

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -9,7 +9,6 @@ import numpy as np
 import pytest
 
 from bids.layout import BIDSLayout, Query
-from bids.layout.index import BIDSLayoutIndexer
 from bids.layout.models import Config
 from bids.tests import get_test_data_path
 from bids.utils import natural_sort
@@ -41,8 +40,7 @@ def test_index_metadata(index_metadata, query, result, mock_config):
     data_dir = join(get_test_data_path(), '7t_trt')
     layout = BIDSLayout(data_dir, index_metadata=index_metadata)
     if not index_metadata and query is not None:
-        indexer = BIDSLayoutIndexer(index_metadata=False)
-        indexer.index(layout, **query)
+        layout.indexer.index_metadata(layout, **query)
     sample_file = layout.get(task='rest', extension='.nii.gz',
                              acquisition='fullbrain')[0]
     metadata = sample_file.get_metadata()

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -321,7 +321,8 @@ def test_ignore_files(layout_ds005):
     # overrides the default - but 'model/extras/' should still be ignored
     # because of the regex.
     ignore = [re.compile('xtra'), 'dummy']
-    layout2 = BIDSLayout(data_dir, validate=False, ignore=ignore)
+    indexer = BIDSLayoutIndexer(validate=False, ignore=ignore)
+    layout2 = BIDSLayout(data_dir, indexer=indexer)
     assert target1 in layout2.files
     assert target2 not in layout2.files
 
@@ -329,7 +330,8 @@ def test_ignore_files(layout_ds005):
 def test_force_index(layout_ds005):
     data_dir = join(get_test_data_path(), 'ds005')
     target = join(data_dir, 'models', 'ds-005_type-test_model.json')
-    model_layout = BIDSLayout(data_dir, validate=True, force_index=['models'])
+    indexer = BIDSLayoutIndexer(force_index=['models'])
+    model_layout = BIDSLayout(data_dir, validate=True, indexer=indexer)
     assert target not in layout_ds005.files
     assert target in model_layout.files
     assert 'all' not in model_layout.get_subjects()

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -41,8 +41,8 @@ def test_index_metadata(index_metadata, query, result, mock_config):
     data_dir = join(get_test_data_path(), '7t_trt')
     layout = BIDSLayout(data_dir, index_metadata=index_metadata)
     if not index_metadata and query is not None:
-        indexer = BIDSLayoutIndexer(layout)
-        indexer.add_metadata(**query)
+        indexer = BIDSLayoutIndexer(index_metadata=False)
+        indexer.index(layout, **query)
     sample_file = layout.get(task='rest', extension='.nii.gz',
                              acquisition='fullbrain')[0]
     metadata = sample_file.get_metadata()

--- a/bids/layout/tests/test_models.py
+++ b/bids/layout/tests/test_models.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import sessionmaker
 import numpy as np
 
 from bids.layout.models import (BIDSFile, Entity, Tag, Base, Config,
-                                FileAssociation, BIDSImageFile)
+                                FileAssociation, BIDSImageFile, LayoutInfo)
 from bids.tests import get_test_data_path
 
 
@@ -36,6 +36,20 @@ def sample_bidsfile(tmpdir):
 def subject_entity():
     return Entity('subject', r"[/\\\\]sub-([a-zA-Z0-9]+)", mandatory=False,
                directory="{subject}", dtype='str')
+
+
+def test_layoutinfo_init():
+    args = dict(root='/made/up/path', validate=True,
+                      absolute_paths=True, index_metadata=False,
+                      derivatives=True, ignore=['code/', 'blergh/'],
+                      force_index=None)
+    with pytest.raises(ValueError) as exc:
+        LayoutInfo(**args)
+        assert exc.value.message.startswith("Missing mandatory")
+    args['config'] = ['bids', 'derivatives']
+    info = LayoutInfo(**args)
+    assert info.derivatives == True
+    assert info._derivatives == 'true'
 
 
 def test_entity_initialization():

--- a/bids/layout/tests/test_models.py
+++ b/bids/layout/tests/test_models.py
@@ -72,8 +72,7 @@ def test_entity_init_all_args(subject_entity):
 def test_entity_init_with_bad_dtype():
     with pytest.raises(ValueError) as exc:
         ent = Entity('test', dtype='superfloat')
-        msg = exc.value.message
-        assert msg.startswith("Invalid dtype")
+    assert str(exc.value).startswith("Invalid dtype")
 
 
 def test_entity_matches(tmpdir):

--- a/bids/layout/tests/test_models.py
+++ b/bids/layout/tests/test_models.py
@@ -40,12 +40,12 @@ def subject_entity():
 
 def test_layoutinfo_init():
     args = dict(root='/made/up/path', validate=True,
-                      absolute_paths=True, index_metadata=False,
-                      derivatives=True, ignore=['code/', 'blergh/'],
-                      force_index=None)
+                absolute_paths=True, index_metadata=False,
+                derivatives=True, ignore=['code/', 'blergh/'],
+                force_index=None)
     with pytest.raises(ValueError) as exc:
         LayoutInfo(**args)
-        assert exc.value.message.startswith("Missing mandatory")
+    assert exc.value.message.startswith("Missing mandatory")
     args['config'] = ['bids', 'derivatives']
     info = LayoutInfo(**args)
     assert info.derivatives == True

--- a/bids/layout/tests/test_models.py
+++ b/bids/layout/tests/test_models.py
@@ -269,6 +269,14 @@ def test_bidsfile_get_entities(layout_synthetic):
     assert set(md.keys()) == md_ents | file_ents
 
 
+def test_bidsfile_relpath(layout_synthetic):
+    bf = layout_synthetic.get(suffix='physio', extension='tsv.gz')[10]
+    assert bf.path != bf.relpath
+    assert layout_synthetic.root in bf.path
+    assert bf.relpath.startswith('sub')
+    assert bf.relpath == str(Path(bf.path).relative_to(layout_synthetic.root))
+
+
 @pytest.mark.xfail(sys.version_info < (3, 6), reason="os.PathLike introduced in Python 3.6")
 def test_bidsfile_fspath(sample_bidsfile):
     bf = sample_bidsfile

--- a/bids/layout/tests/test_models.py
+++ b/bids/layout/tests/test_models.py
@@ -45,7 +45,7 @@ def test_layoutinfo_init():
                 force_index=None)
     with pytest.raises(ValueError) as exc:
         LayoutInfo(**args)
-    assert exc.value.message.startswith("Missing mandatory")
+    assert str(exc.value).startswith("Missing mandatory")
     args['config'] = ['bids', 'derivatives']
     info = LayoutInfo(**args)
     assert info.derivatives == True

--- a/bids/layout/validation.py
+++ b/bids/layout/validation.py
@@ -33,6 +33,14 @@ EXAMPLE_DERIVATIVES_DESCRIPTION = {
 DEFAULT_LOCATIONS_TO_IGNORE = ("code", "stimuli", "sourcedata", "models",
                                re.compile(r'^\.'))
 
+def absolute_path_deprecation_warning():
+    warnings.warn("The absolute_paths argument will be removed from PyBIDS "
+                  "in 0.14. You can easily access the relative path of "
+                  "BIDSFile objects via the .relpath attribute (instead of "
+                  ".path). Switching to this pattern is strongly encouraged, "
+                  "as the current implementation of relative path handling "
+                  "is known to produce query failures in certain edge cases.")
+
 
 def validate_root(root, validate):
     # Validate root argument and make sure it contains mandatory info

--- a/bids/layout/validation.py
+++ b/bids/layout/validation.py
@@ -1,0 +1,159 @@
+"""Functionality related to validation of BIDSLayouts and BIDS projects."""
+
+import os
+import json
+import re
+import warnings
+
+from ..utils import listify
+from ..exceptions import BIDSValidationError, BIDSDerivativesValidationError
+
+
+MANDATORY_BIDS_FIELDS = {
+    "Name": {"Name": "Example dataset"},
+    "BIDSVersion": {"BIDSVersion": "1.0.2"},
+}
+
+
+MANDATORY_DERIVATIVES_FIELDS = {
+    **MANDATORY_BIDS_FIELDS,
+    "PipelineDescription.Name": {
+        "PipelineDescription": {"Name": "Example pipeline"}
+    },
+}
+
+EXAMPLE_BIDS_DESCRIPTION = {
+    k: val[k] for val in MANDATORY_BIDS_FIELDS.values() for k in val}
+
+
+EXAMPLE_DERIVATIVES_DESCRIPTION = {
+    k: val[k] for val in MANDATORY_DERIVATIVES_FIELDS.values() for k in val}
+
+
+DEFAULT_LOCATIONS_TO_IGNORE = ("code", "stimuli", "sourcedata", "models",
+                               re.compile(r'^\.'))
+
+
+def validate_root(root, validate):
+    # Validate root argument and make sure it contains mandatory info
+    try:
+        root = str(root)
+    except:
+        raise TypeError("root argument must be a string (or a type that "
+                        "supports casting to string, such as "
+                        "pathlib.Path) specifying the directory "
+                        "containing the BIDS dataset.")
+
+    root = os.path.abspath(root)
+
+    if not os.path.exists(root):
+        raise ValueError("BIDS root does not exist: %s" % root)
+
+    target = os.path.join(root, 'dataset_description.json')
+    if not os.path.exists(target):
+        if validate:
+            raise BIDSValidationError(
+                "'dataset_description.json' is missing from project root."
+                " Every valid BIDS dataset must have this file."
+                "\nExample contents of 'dataset_description.json': \n%s" %
+                json.dumps(EXAMPLE_BIDS_DESCRIPTION)
+            )
+        else:
+            description = None
+    else:
+        with open(target, 'r', encoding='utf-8') as desc_fd:
+            description = json.load(desc_fd)
+        if validate:
+            for k in MANDATORY_BIDS_FIELDS:
+                if k not in description:
+                    raise BIDSValidationError(
+                        "Mandatory %r field missing from "
+                        "'dataset_description.json'."
+                        "\nExample: %s" % (k, MANDATORY_BIDS_FIELDS[k])
+                    )
+
+    return root, description
+
+
+def validate_derivative_paths(paths, layout=None, **kwargs):
+
+    deriv_dirs = []
+
+    # Collect all paths that contain a dataset_description.json
+    def check_for_description(bids_dir):
+        dd = os.path.join(bids_dir, 'dataset_description.json')
+        return os.path.exists(dd)
+
+    for p in paths:
+        p = os.path.abspath(p)
+        if os.path.exists(p):
+            if check_for_description(p):
+                deriv_dirs.append(p)
+            else:
+                subdirs = [d for d in os.listdir(p)
+                            if os.path.isdir(os.path.join(p, d))]
+                for sd in subdirs:
+                    sd = os.path.join(p, sd)
+                    if check_for_description(sd):
+                        deriv_dirs.append(sd)
+
+    if not deriv_dirs:
+        warnings.warn("Derivative indexing was requested, but no valid "
+                        "datasets were found in the specified locations "
+                        "({}). Note that all BIDS-Derivatives datasets must"
+                        " meet all the requirements for BIDS-Raw datasets "
+                        "(a common problem is to fail to include a "
+                        "'dataset_description.json' file in derivatives "
+                        "datasets).\n".format(paths) +
+                        "Example contents of 'dataset_description.json':\n%s" %
+                        json.dumps(EXAMPLE_DERIVATIVES_DESCRIPTION))
+
+    paths = {}
+
+    for deriv in deriv_dirs:
+        dd = os.path.join(deriv, 'dataset_description.json')
+        with open(dd, 'r', encoding='utf-8') as ddfd:
+            description = json.load(ddfd)
+        pipeline_name = description.get(
+            'PipelineDescription', {}).get('Name')
+        if pipeline_name is None:
+            raise BIDSDerivativesValidationError(
+                                "Every valid BIDS-derivatives dataset must "
+                                "have a PipelineDescription.Name field set "
+                                "inside 'dataset_description.json'. "
+                                "\nExample: %s" %
+                                MANDATORY_DERIVATIVES_FIELDS['PipelineDescription.Name'])
+        if layout is not None and pipeline_name in layout.derivatives:
+            raise BIDSDerivativesValidationError(
+                                "Pipeline name '%s' has already been added "
+                                "to this BIDSLayout. Every added pipeline "
+                                "must have a unique name!")
+        paths[pipeline_name] = deriv
+
+    return paths
+
+
+def validate_indexing_args(ignore, force_index, root):
+    if ignore is None:
+        ignore = DEFAULT_LOCATIONS_TO_IGNORE
+
+    # Do after root validation to ensure os.path.join works
+    ignore = [os.path.abspath(os.path.join(root, patt))
+                    if isinstance(patt, str) else patt
+                    for patt in listify(ignore or [])]
+    force_index = [os.path.abspath(os.path.join(root, patt))
+                   if isinstance(patt, str) else patt
+                   for patt in listify(force_index or [])]
+
+    # Derivatives get special handling; they shouldn't be indexed normally
+    if force_index is not None:
+        for entry in force_index:
+            condi = (isinstance(entry, str) and
+                        os.path.normpath(entry).startswith('derivatives'))
+            if condi:
+                msg = ("Do not pass 'derivatives' in the force_index "
+                        "list. To index derivatives, either set "
+                        "derivatives=True, or use add_derivatives().")
+                raise ValueError(msg)
+
+    return ignore, force_index

--- a/bids/layout/validation.py
+++ b/bids/layout/validation.py
@@ -42,6 +42,16 @@ def absolute_path_deprecation_warning():
                   "is known to produce query failures in certain edge cases.")
 
 
+def indexer_arg_deprecation_warning():
+    warnings.warn("The ability to pass arguments to BIDSLayout that control "
+                  "indexing is likely to be removed in future; possibly as "
+                  "early as PyBIDS 0.14. This includes the `config_filename`, "
+                  "`ignore`, `force_index`, and `index_metadata` arguments. "
+                  "The recommended usage pattern is to initialize a new "
+                  "BIDSLayoutIndexer with these arguments, and pass it to "
+                  "the BIDSLayout via the `indexer` argument.")
+
+
 def validate_root(root, validate):
     # Validate root argument and make sure it contains mandatory info
     try:

--- a/bids/variables/tests/test_collections.py
+++ b/bids/variables/tests/test_collections.py
@@ -58,7 +58,7 @@ def test_run_variable_collection_get_sampling_rate(run_coll):
     coll.variables['RT'].run_info[0] = RunInfo({}, 200, 10, None)
     with pytest.raises(ValueError) as exc:
         coll._get_sampling_rate('TR')
-        assert exc.value.message.startswith('Non-unique')
+    assert str(exc.value).startswith('Non-unique')
     assert coll._get_sampling_rate('highest') == 10
     coll.variables['RT1'] = coll.variables['RT'].to_dense(5.)
     coll.variables['RT2'] = coll.variables['RT'].to_dense(12.)
@@ -66,7 +66,7 @@ def test_run_variable_collection_get_sampling_rate(run_coll):
     assert coll._get_sampling_rate(20) == 20
     with pytest.raises(ValueError) as exc:
         coll._get_sampling_rate('BLARGH')
-        assert exc.value.message.startswith('Invalid')
+    assert str(exc.value).startswith('Invalid')
 
 
 def test_resample_run_variable_collection(run_coll):


### PR DESCRIPTION
The nominal point of this PR is to add a `.relpath` attribute to `BIDSFile` objects that returns the path relative to the `BIDSLayout` root. This provides a proper solution to #625, as it will allow us (in 0.14) to drop the `absolute_paths` argument to `BIDSLayout` that turned out to be the root of all evil.

Unfortunately (or maybe fortunately), adding the `.relpath` property required a non-trivial refactoring of quite a few modules. The reasons for this are probably not worth getting into, but the upshot is that many things are better organized now. Changes include:
* Most validation functionality formerly in `layout.py` is now in a new `validation.py` module. This is mostly cosmetic, but helps reduce the size of `layout.py` and centralizes all validation-related functionality in one place.
* There's a new `LayoutInfo` model that stores basic info about the layout (e.g., its root) inside the DB, instead of saving it to a separate `layout_args.json` sidecar.
* Loading an existing `BIDSLayout` from file behaves a bit differently now. We no longer check to make sure the passed initialization arguments match those of the saved DB file. Instead, if you specify a `database_path` but don't set `reset_database=True`, all initialization settings will be loaded from the DB. This cuts down on some code and is also in my view more intuitive. It eliminates the scenario where a user can't load an existing DB, and needs to reindex, simply because they don't know what arguments the layout was originally saved with, so they can't perfectly match them. This way they don't need to think about initialization arguments at all when using an existing DB.
* I've removed a bunch of arguments from the `BIDSLayout` init. Specifically, all indexing-related arguments except `validate` (i.e., `force_index`, `ignore`, `config_filename`, and `index_metadata`) are now no longer explicitly documented. However, the functionality is preserved (no tests needed fixing for this), because a new `**indexer_args` passes all of those directly to an internally-constructed `BIDSLayoutIndexer`. I'm considering deprecating these arguments entirely and forcing users who want non-default indexing arguments to construct and pass an indexer object themselves (via the new `indexer` argument).
* As discussed in #625, passing the `absolute_paths` argument now raises a deprecation warning (target: 0.14). This mode is now useless, as `.relpath` provides easy access to relative paths.
* The logic in various places has been simplified as a result of the above, and I think thanks to this PR and #642, the `BIDSLayout` code is in general quite a bit easier to understand. I have some ideas for further simplification, but they'll have to wait.

Closes #567 
Closes #609 
Closes #625 (finally!)