### PR TITLE
Require aligned input for logical operations

### DIFF
--- a/bids/analysis/tests/test_transformations.py
+++ b/bids/analysis/tests/test_transformations.py
@@ -461,13 +461,6 @@ def test_and(collection):
     coll = collection.clone()
     transform.Factor(coll, 'respnum')
     names = ['respnum.%d' % d for d in range(0, 5)]
-    # transform.And(coll, names, output='conjunction')
-    # assert not coll.variables['conjunction'].values.sum()
-    #
-    # coll['copy'] = coll.variables['respnum.0'].clone()
-    # transform.And(coll, ['respnum.0', 'copy'], output='conj')
-    # assert coll.variables['conj'].values.astype(float).equals(
-    #     coll.variables['respnum.0'].values)
 
     coll.variables['respnum.0'].onset += 1
 

--- a/bids/analysis/tests/test_transformations.py
+++ b/bids/analysis/tests/test_transformations.py
@@ -461,13 +461,18 @@ def test_and(collection):
     coll = collection.clone()
     transform.Factor(coll, 'respnum')
     names = ['respnum.%d' % d for d in range(0, 5)]
-    transform.And(coll, names, output='conjunction')
-    assert not coll.variables['conjunction'].values.sum()
+    # transform.And(coll, names, output='conjunction')
+    # assert not coll.variables['conjunction'].values.sum()
+    #
+    # coll['copy'] = coll.variables['respnum.0'].clone()
+    # transform.And(coll, ['respnum.0', 'copy'], output='conj')
+    # assert coll.variables['conj'].values.astype(float).equals(
+    #     coll.variables['respnum.0'].values)
 
-    coll['copy'] = coll.variables['respnum.0'].clone()
-    transform.And(coll, ['respnum.0', 'copy'], output='conj')
-    assert coll.variables['conj'].values.astype(float).equals(
-        coll.variables['respnum.0'].values)
+    coll.variables['respnum.0'].onset += 1
+    transform.And(coll, names, output='misaligned')
+
+    transform.And(coll, names, output='misaligned', dense=True)
 
 
 def test_or(collection):

--- a/bids/analysis/tests/test_transformations.py
+++ b/bids/analysis/tests/test_transformations.py
@@ -470,8 +470,12 @@ def test_and(collection):
     #     coll.variables['respnum.0'].values)
 
     coll.variables['respnum.0'].onset += 1
-    transform.And(coll, names, output='misaligned')
 
+    # Should fail because I misaligned variable
+    with pytest.raises(ValueError):
+        transform.And(coll, names, output='misaligned')
+
+    # Should pass because dense is set to True and will align
     transform.And(coll, names, output='misaligned', dense=True)
 
 

--- a/bids/analysis/transformations/base.py
+++ b/bids/analysis/transformations/base.py
@@ -365,8 +365,8 @@ class Transformation(metaclass=ABCMeta):
                             "set dense=True in the Transformation arguments"
                             )
 
-        _aligned_variables = True if not self._align_variables \
-            else self._align_variables
+        _aligned_variables = True if not self._aligned_variables \
+            else self._aligned_variables
         _aligned_variables = [listify(self.kwargs[v])
                               for v in listify(_aligned_variables)
                               if v in self.kwargs]

--- a/bids/analysis/transformations/base.py
+++ b/bids/analysis/transformations/base.py
@@ -351,7 +351,7 @@ class Transformation(metaclass=ABCMeta):
                             for c in variables[1:]]):
                     if self._force_dense_align:
                         msg = ("Forcing all sparse variables to dense in "
-                                "order to ensure proper alignment.")
+                               "order to ensure proper alignment.")
                         sr = self.collection.sampling_rate
                         variables = [c.to_dense(sr) for c in variables]
                         warnings.warn(msg)

--- a/bids/analysis/transformations/base.py
+++ b/bids/analysis/transformations/base.py
@@ -312,7 +312,7 @@ class Transformation(metaclass=ABCMeta):
     def _postprocess(self, col):
         return col
 
-    def _align_variables(self, variables, force=True):
+    def _align_variables(self, variables):
         """Checks whether the specified variables have aligned indexes. This
         implies either that all variables are dense, or that all variables are
         sparse and have exactly the same onsets and durations. If variables are
@@ -332,12 +332,6 @@ class Transformation(metaclass=ABCMeta):
                     sparse_names = [s.name for s in sparse]
                     msg = ("Found a mix of dense and sparse variables. May "
                            "cause problems for some transformations.")
-                    if force:
-                        msg += (" Sparse variables %s were converted to dense "
-                                "form to ensure proper alignment." %
-                                sparse_names)
-                        sr = self.collection.sampling_rate
-                        sparse = [s.to_dense(sr) for s in sparse]
                     warnings.warn(msg)
             # If all are sparse, durations, onsets, and index must match
             # perfectly for all
@@ -352,13 +346,11 @@ class Transformation(metaclass=ABCMeta):
                 fc = get_col_data(variables[0])
                 if not all([compare_variables(fc, get_col_data(c))
                             for c in variables[1:]]):
-                    msg = "Misaligned sparse variables found."
-                    if force:
-                        msg += (" Forcing all sparse variables to dense in "
-                                "order to ensure proper alignment.")
-                        sr = self.collection.sampling_rate
-                        variables = [c.to_dense(sr) for c in variables]
-                    warnings.warn(msg)
+                    raise ValueError(
+                        "Misaligned sparse variables found."
+                        "To force variables into alignment by densifying,"
+                        "set dense=True in the Transformation arguments"
+                    warn
 
         align_variables = [listify(self.kwargs[v])
                            for v in listify(self._align) if v in self.kwargs]

--- a/bids/analysis/transformations/base.py
+++ b/bids/analysis/transformations/base.py
@@ -43,7 +43,8 @@ class Transformation(metaclass=ABCMeta):
 
     # A tuple indicating which arguments give the names of variables that must
     # all be aligned with one another (i.e., onsets and durations match
-    # perfectly) before processing. Defaults to None.
+    # perfectly) before processing.
+    # If True, will require all variables to be aligned. Defaults to None.
     _align = None
 
     # Boolean indicating whether the Transformation should be applied to each

--- a/bids/analysis/transformations/base.py
+++ b/bids/analysis/transformations/base.py
@@ -350,7 +350,7 @@ class Transformation(metaclass=ABCMeta):
                         "Misaligned sparse variables found."
                         "To force variables into alignment by densifying,"
                         "set dense=True in the Transformation arguments"
-                    warn
+                        )
 
         align_variables = [listify(self.kwargs[v])
                            for v in listify(self._align) if v in self.kwargs]

--- a/bids/analysis/transformations/base.py
+++ b/bids/analysis/transformations/base.py
@@ -350,7 +350,7 @@ class Transformation(metaclass=ABCMeta):
                 if not all([compare_variables(fc, get_col_data(c))
                             for c in variables[1:]]):
                     if self._force_dense_align:
-                        msg += (" Forcing all sparse variables to dense in "
+                        msg = ("Forcing all sparse variables to dense in "
                                 "order to ensure proper alignment.")
                         sr = self.collection.sampling_rate
                         variables = [c.to_dense(sr) for c in variables]

--- a/bids/analysis/transformations/compute.py
+++ b/bids/analysis/transformations/compute.py
@@ -197,7 +197,6 @@ class Sum(Transformation):
         return (data * weights).sum(axis=1)
 
 
-
 class Threshold(Transformation):
     """Threshold and/or binarize a variable.
 

--- a/bids/analysis/transformations/compute.py
+++ b/bids/analysis/transformations/compute.py
@@ -107,8 +107,8 @@ class Orthogonalize(Transformation):
 
     _variables_used = ('variables', 'other')
     _densify = ('variables', 'other')
-    _align = ('other')
-    _force_dense_align = True
+    _aligned_required = 'force_dense'
+    _aligned_variables = ('other')
 
     def _transform(self, var, other):
 
@@ -130,7 +130,7 @@ class Product(Transformation):
 
     _loopable = False
     _groupable = False
-    _align = True
+    _aligned_required = True
     _output_required = True
 
     def _transform(self, data):
@@ -182,7 +182,7 @@ class Sum(Transformation):
 
     _loopable = False
     _groupable = False
-    _align = True
+    _aligned_required = True
     _output_required = True
 
     def _transform(self, data, weights=None):
@@ -250,8 +250,7 @@ class And_(Transformation):
     _loopable = False
     _groupable = False
     _output_required = True
-    _align = True
-
+    _aligned_required = True
 
     def _transform(self, dfs):
         df = pd.concat(dfs, axis=1, sort=True)
@@ -286,7 +285,7 @@ class Or_(Transformation):
     _loopable = False
     _groupable = False
     _output_required = True
-    _align = True
+    _aligned_required = True
 
     def _transform(self, dfs):
         df = pd.concat(dfs, axis=1, sort=True)

--- a/bids/analysis/transformations/compute.py
+++ b/bids/analysis/transformations/compute.py
@@ -108,6 +108,7 @@ class Orthogonalize(Transformation):
     _variables_used = ('variables', 'other')
     _densify = ('variables', 'other')
     _align = ('other')
+    _force_dense_align = True
 
     def _transform(self, var, other):
 

--- a/bids/analysis/transformations/compute.py
+++ b/bids/analysis/transformations/compute.py
@@ -268,7 +268,6 @@ class Not(Transformation):
 
     _loopable = True
     _groupable = False
-    _align = True
 
     def _transform(self, var):
         return ~var.astype(bool)

--- a/bids/analysis/transformations/compute.py
+++ b/bids/analysis/transformations/compute.py
@@ -250,6 +250,8 @@ class And_(Transformation):
     _loopable = False
     _groupable = False
     _output_required = True
+    _align = True
+
 
     def _transform(self, dfs):
         df = pd.concat(dfs, axis=1, sort=True)
@@ -267,6 +269,7 @@ class Not(Transformation):
 
     _loopable = True
     _groupable = False
+    _align = True
 
     def _transform(self, var):
         return ~var.astype(bool)
@@ -284,6 +287,7 @@ class Or_(Transformation):
     _loopable = False
     _groupable = False
     _output_required = True
+    _align = True
 
     def _transform(self, dfs):
         df = pd.concat(dfs, axis=1, sort=True)

--- a/bids/analysis/transformations/munge.py
+++ b/bids/analysis/transformations/munge.py
@@ -176,6 +176,7 @@ class Filter(Transformation):
     _input_type = 'variable'
     _return_type = 'variable'
     _align = ('by')
+    _force_dense_align = True
     _allow_categorical = ('variables', 'by')
 
     def _transform(self, var, query, by=None):

--- a/bids/analysis/transformations/munge.py
+++ b/bids/analysis/transformations/munge.py
@@ -175,8 +175,8 @@ class Filter(Transformation):
     _groupable = False
     _input_type = 'variable'
     _return_type = 'variable'
-    _align = ('by')
-    _force_dense_align = True
+    _aligned_required = 'force_dense'
+    _aligned_variables = ('by')
     _allow_categorical = ('variables', 'by')
 
     def _transform(self, var, query, by=None):

--- a/bids/variables/variables.py
+++ b/bids/variables/variables.py
@@ -45,10 +45,14 @@ class BIDSVariable(metaclass=ABCMeta):
         """
         result = deepcopy(self)
         if data is not None:
-            if data.squeeze().shape != self.values.squeeze().shape:
-                raise ValueError("Replacement data has shape %s; must have "
-                                 "same shape as existing data %s." %
-                                 (data.shape, self.values.shape))
+            if data.shape != self.values.shape:
+                # If data can be re-shaped safely, do so
+                if data.squeeze().shape == self.values.squeeze().shape:
+                    data = data.reshape(self.values.shape)
+                else:
+                    raise ValueError("Replacement data has shape %s; must have"
+                                     " same shape as existing data %s." %
+                                     (data.shape, self.values.shape))
             result.values = pd.DataFrame(data)
 
         if kwargs:

--- a/bids/variables/variables.py
+++ b/bids/variables/variables.py
@@ -48,7 +48,7 @@ class BIDSVariable(metaclass=ABCMeta):
             if data.shape != self.values.shape:
                 # If data can be re-shaped safely, do so
                 if data.squeeze().shape == self.values.squeeze().shape:
-                    data = data.reshape(self.values.shape)
+                    data = data.values.reshape(self.values.shape)
                 else:
                     raise ValueError("Replacement data has shape %s; must have"
                                      " same shape as existing data %s." %

--- a/bids/variables/variables.py
+++ b/bids/variables/variables.py
@@ -45,7 +45,7 @@ class BIDSVariable(metaclass=ABCMeta):
         """
         result = deepcopy(self)
         if data is not None:
-            if data.shape != self.values.shape:
+            if data.squeeze().shape != self.values.squeeze().shape:
                 raise ValueError("Replacement data has shape %s; must have "
                                  "same shape as existing data %s." %
                                  (data.shape, self.values.shape))


### PR DESCRIPTION
- Adds `_align` to logical operations.
- Remove `force` option from align method, and set default to equivalent of `False`.
- Add '_force_dense_align` class level attribute which controls if an error should be thrown in events are misaligned, or automatically densified to ensure alignment. 


Closes #648 