### PR TITLE
ENH: Add CLI to PyBIDS

### DIFF
--- a/bids/cli.py
+++ b/bids/cli.py
@@ -63,7 +63,6 @@ def layout(
 ):
     """
     Initialize a BIDSLayout, and create an SQLite database index.
-
     """
 
     # ensure empty multiples are set to None

--- a/bids/cli.py
+++ b/bids/cli.py
@@ -5,7 +5,6 @@ from . import __version__
 from .layout import BIDSLayoutIndexer, BIDSLayout
 from .utils import validate_multiple as _validate_multiple
 
-
 # alias -h to trigger help message
 CONTEXT_SETTINGS = {'help_option_names': ['-h', '--help']}
 
@@ -15,15 +14,12 @@ class PathOrRegex(click.ParamType):
     name = "path or m/regex/"
 
     def convert(self, value, param, ctx):
-        if value.startswith('m/') and value.endswith('/'):
-            # regex pattern
-            import re
+        import re
+        if re.match(r"^m/.*/$", value):  # has form "m/<regex>/"
             value = re.compile(value[2:-1])
-        # otherwise, return as is
         return value
 
 
-# create group of commands as entrypoint
 @click.group(context_settings=CONTEXT_SETTINGS)
 @click.version_option(__version__, prog_name='pybids')
 def cli():

--- a/bids/cli.py
+++ b/bids/cli.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+import click
+
+from . import __version__
+
+# alias -h to trigger help message
+CONTEXT_SETTINGS = {'help_option_names': ['-h', '--help']}
+
+
+class BIDSIndexIgnoreRe(click.ParamType):
+    "A helper Type to parse BIDSLayoutIndexer ignore entries"
+    name = "ignore"
+
+    def convert(self, value, param, ctx):
+        import re
+        # will this ever fail?
+        return re.compile(value)
+
+
+# create group of commands as entrypoint
+@click.group(context_settings=CONTEXT_SETTINGS)
+@click.version_option(__version__, prog_name='pybids')
+def cli():
+    """Command-line interface for PyBIDS operations"""
+    pass
+
+
+@cli.command(context_settings=CONTEXT_SETTINGS)
+@click.argument('root', type=click.Path(file_okay=False, exists=True))
+@click.option('--output', type=click.Path(file_okay=False, resolve_path=True),
+              default=Path('.').resolve(), help="Path to save database index")
+@click.option('--skip-validation', default=False, is_flag=True,
+              help="Skip check for BIDS compliance when indexing files.")
+@click.option('--skip-metadata', default=False, is_flag=True,
+              help="Skip metadata when indexing files.")
+@click.option('--ignore-path', multiple=True, default=None,
+              help="Path (from root) to exclude from indexing.")
+@click.option('--ignore-regex', multiple=True, default=None, type=BIDSIndexIgnoreRe(),
+              help="Regex to exclude from indexing.")
+def save_db(root, output, skip_validation, skip_metadata, ignore_path, ignore_regex):
+    """Initialize and save an SQLite database index for this BIDS dataset.
+
+    If ``output`` contains a previously generated index, this method will raise a
+    ``RuntimeError``.
+    """
+    if (Path(output) / 'layout_index.sqlite').exists():
+        raise RuntimeError("Previous index exists at {}".format(output))
+
+    ignore = None
+    if ignore_path or ignore_regex:
+        ignore = ignore_path + ignore_regex
+
+    indexer = _init_indexer(
+        validate=not skip_validation,
+        index_metadata=not skip_metadata,
+        ignore=ignore,
+    )
+
+    layout = _init_layout(
+        root,
+        validate=not skip_validation,
+        indexer=indexer,
+    )
+    layout.save(output)
+    click.echo("Successfully generated database index at {}".format(output))
+
+
+def _init_indexer(**kwargs):
+    from .layout import BIDSLayoutIndexer
+
+    return BIDSLayoutIndexer(**kwargs)
+
+
+def _init_layout(root, **kwargs):
+    from .layout import BIDSLayout
+
+    return BIDSLayout(root, **kwargs)

--- a/bids/tests/test_cli.py
+++ b/bids/tests/test_cli.py
@@ -3,12 +3,14 @@ import os
 from click.testing import CliRunner
 import pytest
 
-from bids.cli import cli
+from bids.cli import cli, _validate_multiple
 from bids.tests import get_test_data_path
+
 
 @pytest.fixture
 def runner():
     return CliRunner()
+
 
 def test_cli_entrypoint(runner):
     res = runner.invoke(cli, catch_exceptions=False)
@@ -16,6 +18,15 @@ def test_cli_entrypoint(runner):
     assert runner.invoke(cli, ['-h'], catch_exceptions=False).stdout == res.stdout
     # verify versioning
     assert runner.invoke(cli, ['--version'], catch_exceptions=False).stdout.startswith('pybids')
+
+
+def test_validate_multiple():
+    assert _validate_multiple(()) is None
+    assert _validate_multiple((), retval=False) is False
+    assert _validate_multiple(('bids',)) == 'bids'
+    assert _validate_multiple((1, 2)) == (1, 2)
+    with pytest.raises(AssertionError):
+        _validate_multiple('not a tuple')
 
 
 def test_layout(runner, tmp_path):

--- a/bids/tests/test_cli.py
+++ b/bids/tests/test_cli.py
@@ -3,7 +3,8 @@ import os
 from click.testing import CliRunner
 import pytest
 
-from bids.cli import cli, _validate_multiple
+from bids.cli import cli
+from bids.utils import validate_multiple
 from bids.tests import get_test_data_path
 
 
@@ -21,12 +22,12 @@ def test_cli_entrypoint(runner):
 
 
 def test_validate_multiple():
-    assert _validate_multiple(()) is None
-    assert _validate_multiple((), retval=False) is False
-    assert _validate_multiple(('bids',)) == 'bids'
-    assert _validate_multiple((1, 2)) == (1, 2)
+    assert validate_multiple(()) is None
+    assert validate_multiple((), retval=False) is False
+    assert validate_multiple(('bids',)) == 'bids'
+    assert validate_multiple((1, 2)) == (1, 2)
     with pytest.raises(AssertionError):
-        _validate_multiple('not a tuple')
+        validate_multiple('not a tuple')
 
 
 def test_layout(runner, tmp_path):
@@ -39,14 +40,14 @@ def test_layout(runner, tmp_path):
     bids_dir = os.path.join(get_test_data_path(), 'ds005')
     db0 = tmp_path / "db0"
     db0.mkdir()
-    res = runner.invoke(cli, ['layout', bids_dir, '--db-path', str(db0)], catch_exceptions=False)
+    res = runner.invoke(cli, ['layout', bids_dir, str(db0)], catch_exceptions=False)
     assert is_success(res)
     # rerunning targeting the save directory should not generate a new index
-    res = runner.invoke(cli, ['layout', bids_dir, '--output', str(db0)], catch_exceptions=False)
+    res = runner.invoke(cli, ['layout', bids_dir, str(db0)], catch_exceptions=False)
     assert not is_success(res)
     # but forcing it should
     res = runner.invoke(
-        cli, ['layout', bids_dir, '--db-path', str(db0), '--reset-db'], catch_exceptions=False
+        cli, ['layout', bids_dir, str(db0), '--reset-db'], catch_exceptions=False
     )
     assert is_success(res)
 
@@ -56,9 +57,9 @@ def test_layout(runner, tmp_path):
     res = runner.invoke(
         cli,
         [
-            'layout', bids_dir, '--db-path', str(db1),
+            'layout', bids_dir, str(db1),
             '--validate', '--no-index-metadata',
-            '--ignore', 'derivatives', '--ignore', 'sourcedata', '--ignore', r'/^\./',
+            '--ignore', 'derivatives', '--ignore', 'sourcedata', '--ignore', r'm/^\./',
             '--force-index', 'test',
             '--config', 'bids',
         ],

--- a/bids/tests/test_cli.py
+++ b/bids/tests/test_cli.py
@@ -1,0 +1,47 @@
+import os
+
+from click.testing import CliRunner
+import pytest
+
+from bids.cli import cli
+from bids.tests import get_test_data_path
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+def test_cli_entrypoint(runner):
+    res = runner.invoke(cli, catch_exceptions=False)
+    assert "Command-line interface for PyBIDS operations" in res.stdout
+    assert runner.invoke(cli, ['-h'], catch_exceptions=False).stdout == res.stdout
+    # verify versioning
+    assert runner.invoke(cli, ['--version'], catch_exceptions=False).stdout.startswith('pybids')
+
+
+def test_save_db(runner, tmp_path):
+    res = runner.invoke(cli, ['save-db', '--help'])
+    assert "Initialize and save an SQLite database index for this BIDS dataset" in res.stdout
+
+    bids_dir = os.path.join(get_test_data_path(), 'ds005')
+    db0 = tmp_path / "db0"
+    db0.mkdir()
+    res = runner.invoke(cli, ['save-db', bids_dir, '--output', str(db0)], catch_exceptions=False)
+    assert res.stdout.startswith("Successfully generated database index")
+    # rerunning targeting the save directory should fail
+    with pytest.raises(RuntimeError):
+        runner.invoke(cli, ['save-db', bids_dir, '--output', str(db0)], catch_exceptions=False)
+
+    db1 = tmp_path / "db1"
+    db1.mkdir()
+    # throw all valid options at it
+    res = runner.invoke(
+        cli,
+        [
+            'save-db', bids_dir, '--output', str(db1),
+            '--skip-validation', '--skip-metadata',
+            '--ignore-path', 'derivatives', '--ignore-path', 'sourcedata',
+            '--ignore-regex', r'^\.',
+        ],
+        catch_exceptions=False,
+    )
+    assert res.stdout.startswith("Successfully generated database index")

--- a/bids/utils.py
+++ b/bids/utils.py
@@ -111,3 +111,18 @@ def make_bidsfile(filename):
 
     Cls = getattr(models, cls)
     return Cls(filename)
+
+
+def validate_multiple(val, retval=None):
+    """Any click.Option with the multiple flag will return an empty tuple if not set.
+
+    This helper method converts empty tuples to a desired return value (default: None).
+    This helper method selects the first item in single-item tuples.
+    """
+    assert isinstance(val, tuple)
+
+    if val == tuple():
+        return retval
+    if len(val) == 1:
+        return val[0]
+    return val

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     sqlalchemy
     bids-validator
     num2words
+    click
 tests_require =
     pytest >=3.3
     mock
@@ -63,6 +64,10 @@ tutorial =
 dev =
     %(doc)s
     %(test)s
+
+[options.entry_points]
+console_scripts =
+    pybids=bids.cli:cli
 
 [versioneer]
 VCS = git


### PR DESCRIPTION
To streamline operations that would require a dedicated script or starting an interactive python session.

Currently just supports generation of a database index, to facilitate processing of large datasets, as well as a version check. The database index can be customized by certain kwargs for `BIDSLayout` and `BIDSLayoutIndex` classes.

This should be extendible for other operations down the line.

- Adds `click` as a dependency - its handling of sub-parsers is a bit more intuitive than `argparse` IMO.