### PR TITLE
ENH: Add ``pybids upgrade`` command

### DIFF
--- a/bids/cli.py
+++ b/bids/cli.py
@@ -140,17 +140,18 @@ def upgrade(root):
     # Rename regressors.tsv to timeseries.tsv
     regressors = layout.get(suffix="regressors")
     policy = None
-    for bidsfile in regressors:
-        action = policy
-        new_path = bidsfile.path.replace("regressors.", "timeseries.")
-        if action is None:
-            action = click.prompt(
-                f"Rename {bidsfile.path} to {new_path}? ([y]es/[n]o/[A]ll/[N]one)", default="y"
-                type=click.Choice("ynAN"), show_choices=False)
-            if action in "AN":
-                policy = action
-        if action in "yA":
-            click.echo(f"Renaming {bidsfile.path} -> {new_path}")
-            os.rename(bidsfile.path, new_path)
-        else:
-            print(f"Not renaming {bidsfile.path}")
+    with click.progressbar(regressors) as bar:
+        for bidsfile in bar:
+            action = policy
+            new_path = bidsfile.path.replace("regressors.", "timeseries.")
+            if action is None:
+                action = click.prompt(
+                    f"Rename {bidsfile.path} to {new_path}? ([y]es/[n]o/[A]ll/[N]one)", default="y"
+                    type=click.Choice("ynAN"), show_choices=False)
+                if action in "AN":
+                    policy = action
+            if action in "yA":
+                click.echo(f"Renaming {bidsfile.path} -> {new_path}")
+                os.rename(bidsfile.path, new_path)
+            else:
+                click.echo(f"Not renaming {bidsfile.path}")

--- a/bids/cli.py
+++ b/bids/cli.py
@@ -100,7 +100,7 @@ def layout(
         )
 
 
-@click.command(context_settings=CONTEXT_SETTINGS)
+@cli.command(context_settings=CONTEXT_SETTINGS)
 @click.argument('root', type=click.Path(file_okay=False, exists=True))
 def upgrade(root):
     """
@@ -112,13 +112,14 @@ def upgrade(root):
 
     # Always update DatasetType if missing
     if "DatasetType" not in description:
-        val = click.prompt("Is this dataset [R]aw or [D]erivative?", default="R",
-                           type=click.Choice("RD"))
+        val = click.prompt("Is this dataset [r]aw or [d]erivative?", default="r",
+                           type=click.Choice(("r", "d"), case_sensitive=False))
         description["DatasetType"] = "raw" if val == "R" else "derivative"
     dstype = description["DatasetType"]
 
     if dstype == "raw":
-        """ No other upgrades for raw datasets at present... """
+        click.echo("No other upgrades for raw datasets at present.")
+        return
     elif dstype == "derivative":
         if "PipelineDescription" in description:
             val = click.prompt("Convert PipelineDescription to GeneratedBy?", default="Y",
@@ -149,7 +150,7 @@ def upgrade(root):
             if action in "AN":
                 policy = action
         if action in "yA":
-            print(f"Renaming {bidsfile.path} -> {new_path}")
+            click.echo(f"Renaming {bidsfile.path} -> {new_path}")
             os.rename(bidsfile.path, new_path)
         else:
             print(f"Not renaming {bidsfile.path}")

--- a/bids/cli.py
+++ b/bids/cli.py
@@ -1,3 +1,6 @@
+import os
+import json
+from copy import deepcopy
 from pathlib import Path
 import click
 
@@ -95,3 +98,58 @@ def layout(
             "Previously generated database index found at {}. "
             "To generate a new index, rerun with ``--reset-db``".format(db_path)
         )
+
+
+@click.command(context_settings=CONTEXT_SETTINGS)
+@click.argument('root', type=click.Path(file_okay=False, exists=True))
+def upgrade(root):
+    """
+    Upgrade common experimental BIDS features to finalized versions.
+    """
+    description_path = Path(root) / "dataset_description.json"
+    description = json.loads(description_path.read_text())
+    orig = deepcopy(description)
+
+    # Always update DatasetType if missing
+    if "DatasetType" not in description:
+        val = click.prompt("Is this dataset [R]aw or [D]erivative?", default="R",
+                           type=click.Choice("RD"))
+        description["DatasetType"] = "raw" if val == "R" else "derivative"
+    dstype = description["DatasetType"]
+
+    if dstype == "raw":
+        """ No other upgrades for raw datasets at present... """
+    elif dstype == "derivative":
+        if "PipelineDescription" in description:
+            val = click.prompt("Convert PipelineDescription to GeneratedBy?", default="Y",
+                               type=click.Choice("YN"))
+            if val == "Y":
+                description["GeneratedBy"] = [description.pop("PipelineDescription")]
+
+    if description != orig:
+        description_path.write_text(json.dumps(description))
+
+    val = click.prompt("Load dataset and update filenames?", default="Y",
+                       type=click.Choice("YN"))
+    if val == "N":
+        return
+
+    layout = BIDSLayout(root, validate=False, config="bids" if dstype == "raw" else "derivatives")
+
+    # Rename regressors.tsv to timeseries.tsv
+    regressors = layout.get(suffix="regressors")
+    policy = None
+    for bidsfile in regressors:
+        action = policy
+        new_path = bidsfile.path.replace("regressors.", "timeseries.")
+        if action is None:
+            action = click.prompt(
+                f"Rename {bidsfile.path} to {new_path}? ([y]es/[n]o/[A]ll/[N]one)", default="y"
+                type=click.Choice("ynAN"), show_choices=False)
+            if action in "AN":
+                policy = action
+        if action in "yA":
+            print(f"Renaming {bidsfile.path} -> {new_path}")
+            os.rename(bidsfile.path, new_path)
+        else:
+            print(f"Not renaming {bidsfile.path}")

--- a/bids/cli.py
+++ b/bids/cli.py
@@ -110,6 +110,12 @@ def upgrade(root):
     description = json.loads(description_path.read_text())
     orig = deepcopy(description)
 
+    click.echo(
+        "WARNING. This upgrade tool is EXPERIMENTAL and MAY damage your "
+        "dataset. Please ensure you have a backup before proceeding."
+    )
+    click.confirm("Proceed?", abort=True)
+
     # Always update DatasetType if missing
     if "DatasetType" not in description:
         val = click.prompt("Is this dataset [r]aw or [d]erivative?", default="r",

--- a/bids/cli.py
+++ b/bids/cli.py
@@ -146,7 +146,7 @@ def upgrade(root):
             new_path = bidsfile.path.replace("regressors.", "timeseries.")
             if action is None:
                 action = click.prompt(
-                    f"Rename {bidsfile.path} to {new_path}? ([y]es/[n]o/[A]ll/[N]one)", default="y"
+                    f"Rename {bidsfile.path} to {new_path}? ([y]es/[n]o/[A]ll/[N]one)", default="y",
                     type=click.Choice("ynAN"), show_choices=False)
                 if action in "AN":
                     policy = action

--- a/bids/layout/validation.py
+++ b/bids/layout/validation.py
@@ -17,8 +17,8 @@ MANDATORY_BIDS_FIELDS = {
 
 MANDATORY_DERIVATIVES_FIELDS = {
     **MANDATORY_BIDS_FIELDS,
-    "PipelineDescription.Name": {
-        "PipelineDescription": {"Name": "Example pipeline"}
+    "GeneratedBy": {
+        "GeneratedBy": [{"Name": "Example pipeline"}]
     },
 }
 
@@ -144,8 +144,9 @@ def validate_derivative_paths(paths, layout=None, **kwargs):
         dd = os.path.join(deriv, 'dataset_description.json')
         with open(dd, 'r', encoding='utf-8') as ddfd:
             description = json.load(ddfd)
-        pipeline_name = description.get(
-            'PipelineDescription', {}).get('Name')
+        pipeline_names = [pipeline.get('Name')
+                          for pipeline in description.get('GeneratedBy')]
+        pipeline_name = pipeline_names[0]
         if pipeline_name is None:
             raise BIDSDerivativesValidationError(
                                 "Every valid BIDS-derivatives dataset must "


### PR DESCRIPTION
This command is intended to provide an interactive guide to upgrading a dataset that included features that were part of a BEP to the final versions, once the BEP was finalized and included in BIDS.

The initial use case is fMRIPrep derivatives that predate BIDS 1.4.0. There will surely be others for derivative and raw data.

This is in preparation to enable BIDS 1.4.0 support, especially the transition from `PipelineDescription` to `GeneratedBy`.