### PR TITLE
FIX: Explicitly convert to HTML when testing tutorial (nbconvert 6.0 breakage)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ travis_tests:
 	pytest --doctest-modules -n 2 -v --cov bids --cov-config .coveragerc --cov-report xml:cov.xml bids
 
 tutorial:
-	jupyter nbconvert --execute examples/pybids_tutorial.ipynb
+	jupyter nbconvert --execute examples/pybids_tutorial.ipynb --to html
 
 doc:
 	$(MAKE) -C doc html


### PR DESCRIPTION
Should fix Travis.

ref: https://github.com/jupyter/nbconvert/pull/1192