### PR TITLE
FIX: Sanitize single derivative Path passed to BIDSLayout

### DIFF
--- a/bids/layout/models.py
+++ b/bids/layout/models.py
@@ -60,7 +60,7 @@ class LayoutInfo(Base):
             kwargs['root'] = str(Path(kwargs['root']).absolute())
 
         # Get abspaths
-        if 'derivatives' in kwargs and isinstance(kwargs['derivatives'], list):
+        if kwargs.get('derivatives') not in (None, True, False):
             kwargs['derivatives'] = [
                 str(Path(der).absolute())
                 for der in listify(kwargs['derivatives'])

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -3,7 +3,8 @@ BIDSLayout class."""
 
 import os
 import re
-from os.path import (join, abspath, basename)
+from os.path import join, abspath, basename
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -509,6 +510,21 @@ def test_deriv_indexing():
     # Should work fine
     deriv_dir = join(data_dir, 'derivatives', 'events')
     layout = BIDSLayout(data_dir, derivatives=deriv_dir)
+    assert layout.get(scope='derivatives')
+    assert layout.get(scope='events')
+    assert not layout.get(scope='nonexistent')
+
+
+def test_path_arguments():
+    data_dir = join(get_test_data_path(), 'ds005')
+    deriv_dir = join(data_dir, 'derivatives', 'events')
+
+    layout = BIDSLayout(Path(data_dir), derivatives=Path(deriv_dir))
+    assert layout.get(scope='derivatives')
+    assert layout.get(scope='events')
+    assert not layout.get(scope='nonexistent')
+
+    layout = BIDSLayout(Path(data_dir), derivatives=[Path(deriv_dir)])
     assert layout.get(scope='derivatives')
     assert layout.get(scope='events')
     assert not layout.get(scope='nonexistent')

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -186,12 +186,12 @@ def test_get_metadata_error(layout_7t_trt):
     result = layout_7t_trt.files[path].get_metadata()
     with pytest.raises(KeyError) as err:
         result['Missing']
-    assert "Metadata term 'Missing' unavailable for file {}".format(path) in str(err)
+    assert "Metadata term 'Missing' unavailable for file {}".format(path) in str(err.value)
 
     result = layout_7t_trt.get_metadata(path)
     with pytest.raises(KeyError) as err:
         result['Missing']
-    assert "Metadata term 'Missing' unavailable for file {}".format(path) in str(err)
+    assert "Metadata term 'Missing' unavailable for file {}".format(path) in str(err.value)
 
 
 def test_get_with_bad_target(layout_7t_trt):

--- a/bids/layout/validation.py
+++ b/bids/layout/validation.py
@@ -103,7 +103,7 @@ def validate_derivative_paths(paths, layout=None, **kwargs):
         return os.path.exists(dd)
 
     for p in paths:
-        p = os.path.abspath(p)
+        p = os.path.abspath(str(p))
         if os.path.exists(p):
             if check_for_description(p):
                 deriv_dirs.append(p)


### PR DESCRIPTION
Starting with a regression test.

Fixes #655.