### PR TITLE
FIX: Do not error when popping missing scan_length

### DIFF
--- a/bids/analysis/analysis.py
+++ b/bids/analysis/analysis.py
@@ -100,7 +100,7 @@ class Analysis(object):
             step.add_collections(drop_na=drop_na, **selectors)
 
         if finalize:
-            selectors.pop('scan_length')  # see TODO below
+            selectors.pop('scan_length', None)  # see TODO below
             self.finalize(**selectors)
 
     def finalize(self, **kwargs):

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     nibabel >=2.1
     pandas >=0.23
     patsy
-    sqlalchemy
+    sqlalchemy == 1.3.20
     bids-validator
     num2words
     click

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     nibabel >=2.1
     pandas >=0.23
     patsy
-    sqlalchemy == 1.3.20
+    sqlalchemy <1.4.0.dev0
     bids-validator
     num2words
     click


### PR DESCRIPTION
Trying to run fitlins tests and I ran into a pybids issue:

```
 File "/data/nielsond/python/envs/fitlins_dev/lib/python3.6/site-packages/bids/analysis/analysis.py", line 103, in setup
    selectors.pop('scan_length')  # see TODO below
KeyError: 'scan_length'
```

Based on feedback from @effigies, I added a default `None` to the  `scan_length` pops. 