### PR TITLE
FIX: BIDSLayout -- TypeError: unhashable type: 'dict'

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -207,7 +207,7 @@ class BIDSLayout(object):
                 (t.value, t.file.entities.get('subject'))
                  for t in
                  self.session.query(Tag).filter_by(entity_name='run')
-                 if t.file.entities.get('subject')
+                 if isinstance(t.value, int) and t.file.entities.get('subject')
                  )
             )
 

--- a/bids/tests/data/7t_trt/sub-01/ses-1/sub-01_ses-1_scans.json
+++ b/bids/tests/data/7t_trt/sub-01/ses-1/sub-01_ses-1_scans.json
@@ -1,0 +1,5 @@
+{
+	"run": {
+		"Description": "metadata to cause #681"
+	}
+}


### PR DESCRIPTION
## Summary
When `BIDSLayout.__repr__` is called on datasets that have `sub-N_scans.tsv` files, the query to obtain runs also returns these files, and their value is a dictionary which is not hashable by the `set` object wrapping up the query.

## Workaround
Instead of refining the query (which indeed would fix the issue), this workaround uses the naive approach of ensuring that each result of the query has `int` value.

Resolves: #681.