### PR TITLE
MAINT: Update numpy dependency requirement for Python <3.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ classifiers =
 python_requires = >=3.5
 install_requires =
     numpy
-    numpy <1.20; python_version < 3.7
+    numpy <1.20; python_version < "3.7"
     scipy
     nibabel >=2.1
     pandas >=0.23

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifiers =
 python_requires = >=3.5
 install_requires =
     numpy
+    numpy <1.20; python_version < 3.7
     scipy
     nibabel >=2.1
     pandas >=0.23


### PR DESCRIPTION
The recently released numpy 1.20 drops Python 3.6