### PR TITLE
ENH: Add flip, inv, mt, and part entities

### DIFF
--- a/bids/layout/config/bids-nodot.json
+++ b/bids/layout/config/bids-nodot.json
@@ -50,6 +50,22 @@
             "pattern": "[_/\\\\]+echo-([0-9]+)"
         },
         {
+            "name": "flip",
+            "pattern": "[_/\\\\]+flip-([0-9]+)"
+        },
+        {
+            "name": "inv",
+            "pattern": "[_/\\\\]+inv-([0-9]+)"
+        },
+        {
+            "name": "mt",
+            "pattern": "[_/\\\\]+mt-(on|off)"
+        },
+        {
+            "name": "part",
+            "pattern": "[_/\\\\]+part-(imag|mag|phase|real)"
+        },
+        {
             "name": "recording",
             "pattern": "[_/\\\\]+recording-([a-zA-Z0-9]+)"
         },

--- a/bids/layout/config/bids.json
+++ b/bids/layout/config/bids.json
@@ -50,6 +50,22 @@
             "pattern": "[_/\\\\]+echo-([0-9]+)"
         },
         {
+            "name": "flip",
+            "pattern": "[_/\\\\]+flip-([0-9]+)"
+        },
+        {
+            "name": "inv",
+            "pattern": "[_/\\\\]+inv-([0-9]+)"
+        },
+        {
+            "name": "mt",
+            "pattern": "[_/\\\\]+mt-(on|off)"
+        },
+        {
+            "name": "part",
+            "pattern": "[_/\\\\]+part-(imag|mag|phase|real)"
+        },
+        {
             "name": "recording",
             "pattern": "[_/\\\\]+recording-([a-zA-Z0-9]+)"
         },

--- a/bids/layout/config/bids.json
+++ b/bids/layout/config/bids.json
@@ -96,10 +96,11 @@
     ],
 
     "default_path_patterns": [
-        "sub-{subject}[/ses-{session}]/{datatype<anat>|anat}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}]_{suffix<T1w|T2w|T1rho|T1map|T2map|T2star|FLAIR|FLASH|PDmap|PD|PDT2|inplaneT[12]|angio>}{extension<.nii|.nii.gz|.json>|.nii.gz}",
+        "sub-{subject}[/ses-{session}]/{datatype<anat>|anat}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}][_part-{part}]_{suffix<T1w|T2w|T1rho|T1map|T2map|T2star|FLAIR|FLASH|PDmap|PD|PDT2|inplaneT[12]|angio>}{extension<.nii|.nii.gz|.json>|.nii.gz}",
         "sub-{subject}[/ses-{session}]/{datatype<anat>|anat}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}][_mod-{modality}]_{suffix<defacemask>}{extension<.nii|.nii.gz|.json>|.nii.gz}",
-        "sub-{subject}[/ses-{session}]/{datatype<func>|func}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_dir-{direction}][_rec-{reconstruction}][_run-{run}][_echo-{echo}]_{suffix<bold|cbv|phase|sbref>}{extension<.nii|.nii.gz|.json>|.nii.gz}",
-        "sub-{subject}[/ses-{session}]/{datatype<dwi>|dwi}/sub-{subject}[_ses-{session}][_acq-{acquisition}]_{suffix<dwi>}{extension<.bval|.bvec|.json|.nii.gz|.nii>|.nii.gz}",
+        "sub-{subject}[/ses-{session}]/{datatype<func>|func}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_dir-{direction}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_part-{part}]_{suffix<bold|cbv|sbref>}{extension<.nii|.nii.gz|.json>|.nii.gz}",
+        "sub-{subject}[/ses-{session}]/{datatype<func>|func}/sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_ce-{ceagent}][_dir-{direction}][_rec-{reconstruction}][_run-{run}][_echo-{echo}]_{suffix<phase>}{extension<.nii|.nii.gz|.json>|.nii.gz}",
+        "sub-{subject}[/ses-{session}]/{datatype<dwi>|dwi}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_part-{part}]_{suffix<dwi>}{extension<.bval|.bvec|.json|.nii.gz|.nii>|.nii.gz}",
         "sub-{subject}[/ses-{session}]/{datatype<fmap>|fmap}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_dir-{direction}][_run-{run}]_{fmap<phasediff|magnitude[12]|phase[12]|fieldmap>}{extension<.nii|.nii.gz|.json>|.nii.gz}",
         "sub-{subject}[/ses-{session}]/{datatype<fmap>|fmap}/sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{ceagent}]_dir-{direction}[_run-{run}]_{fmap<epi>}{extension<.nii|.nii.gz|.json>|.nii.gz}",
         "sub-{subject}[/ses-{session}]/[{datatype<func|meg|beh>|func}/]sub-{subject}[_ses-{session}]_task-{task}[_acq-{acquisition}][_rec-{reconstruction}][_run-{run}][_echo-{echo}][_recording-{recording}]_{suffix<events>}{extension<.tsv|.json>|.tsv}",


### PR DESCRIPTION
BIDS has added new entities for flip angle (`flip`), inversion time (`inv`), magnetization transfer state (`mt`), and component of the complex signal (`part`). These entities have been merged into the specification, but the updates haven't been released yet, although we expect a release within the next month or so.

I didn't see any associated tests for the `echo` entity, so I'm guessing that there are no tests associated with the config files. Please correct me if I'm wrong.

Changes proposed:
- Add patterns for `flip`, `inv`, `mt`, and `part` entities.
- Incorporate `part` into path patterns. The other entities have not been integrated into any suffixes yet, as there are still BEP001-related PRs pending.