### PR TITLE
FIX: Correctly pair metadata file when creating association records

### DIFF
--- a/bids/layout/index.py
+++ b/bids/layout/index.py
@@ -360,7 +360,7 @@ class BIDSLayoutIndexer:
                 continue
 
             # Create DB records for metadata associations
-            js_file = payloads[-1][1]
+            js_file = payloads[0][1]
             create_association_pair(js_file, bf.path, 'Metadata')
 
             # Consolidate metadata by looping over inherited JSON files

--- a/bids/layout/models.py
+++ b/bids/layout/models.py
@@ -261,12 +261,17 @@ class BIDSFile(Base):
         list
             A list of BIDSFile instances.
         """
-        if kind is None:
+        if kind is None and not include_parents:
             return self._associations
+
         session = object_session(self)
         q = (session.query(BIDSFile)
              .join(FileAssociation, BIDSFile.path == FileAssociation.dst)
-             .filter_by(kind=kind, src=self.path))
+             .filter_by(src=self.path))
+
+        if kind is not None:
+            q = q.filter_by(kind=kind)
+
         associations = q.all()
 
         if not include_parents:
@@ -278,7 +283,7 @@ class BIDSFile(Base):
                 results = collect_associations(results, p)
             return results
 
-        return chain(*[collect_associations([], bf) for bf in associations])
+        return list(chain(*[collect_associations([], bf) for bf in associations]))
 
     def get_metadata(self):
         """Return all metadata associated with the current file. """

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -582,20 +582,30 @@ def test_indexed_file_associations(layout_7t_trt):
                             acquisition='fullbrain', extension='.nii.gz')[0]
     assocs = img.get_associations()
     assert len(assocs) == 3
-    targets = [
+    targets = {
         os.path.join(layout_7t_trt.root,
                      'sub-01/ses-1/fmap/sub-01_ses-1_run-1_phasediff.nii.gz'),
         os.path.join(
             img.dirname,
             'sub-01_ses-1_task-rest_acq-fullbrain_run-1_physio.tsv.gz'),
-        os.path.join(layout_7t_trt.root, 'task-rest_acq-fullbrain_bold.json')
-    ]
+        os.path.join(
+            img.dirname,
+            'sub-01_ses-1_task-rest_acq-fullbrain_run-1_bold.json'
+        )
+    }
     assert set([a.path for a in assocs]) == set(targets)
 
-    js = [a for a in assocs if a.path.endswith('json')][0]
-    assert len(js.get_associations()) == 41
+    # Test with parents included
+    targets.add(os.path.join(layout_7t_trt.root, 'task-rest_acq-fullbrain_bold.json'))
+    assocs = img.get_associations(include_parents=True)
+    assert len(assocs) == 4
+    assert set([a.path for a in assocs]) == set(targets)
+
+    # Get the root-level JSON and check that its associations are correct
+    js = [a for a in assocs if a.path.endswith('json')][1]
+    assert len(js.get_associations()) == 40
     assert len(js.get_associations('Parent')) == 1
-    assert len(js.get_associations('Metadata')) == 40
+    assert len(js.get_associations('Metadata')) == 39
     assert not js.get_associations('InformedBy')
 
 


### PR DESCRIPTION
Fixes #692. When more than one JSON file was present in the inheritance chain, the wrong file was being used as the direct sidecar for the target file (most distant instead of most recent). This didn't have any effect on the order in which metadata files were actually examined/indexed (i.e., the BIDS spec was still being followed correctly), which is probably why it took this long to notice it. It would only manifest in having the wrong associated files returned when calling `get_associations()` under certain conditions.

(In the process of fixing the above, I also caught another, undetected bug, where `include_parents` was being ignored when `kind` was set to `None`.)