### PR TITLE
ENH: Add res/den entities to derivatives.json

### DIFF
--- a/bids/layout/config/derivatives.json
+++ b/bids/layout/config/derivatives.json
@@ -34,12 +34,12 @@
             "pattern": "hemi-(L|R)"
         },
         {
-            "name": "den",
-            "pattern": "den-([a-zA-Z0-9]+)"
+            "name": "res",
+            "pattern": "res-([a-zA-Z0-9]+)"
         },
         {
-            "name": "space",
-            "pattern": "space-([a-zA-Z0-9]+)"
+            "name": "den",
+            "pattern": "den-([a-zA-Z0-9]+)"
         },
         {
             "name": "model",

--- a/bids/layout/config/derivatives.json
+++ b/bids/layout/config/derivatives.json
@@ -34,6 +34,14 @@
             "pattern": "hemi-(L|R)"
         },
         {
+            "name": "den",
+            "pattern": "den-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "space",
+            "pattern": "space-([a-zA-Z0-9]+)"
+        },
+        {
             "name": "model",
             "pattern": "model-([a-zA-Z0-9]+)"
         },


### PR DESCRIPTION
Squashed #698 and updated.

* Space entity is already in bids.json, and duplicates aren't permitted.
* Might as well add the res entity while updating den