### PR TITLE
typos: as identified by codespell

### DIFF
--- a/bids/_version.py
+++ b/bids/_version.py
@@ -268,7 +268,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
         # TAG-NUM-gHEX
         mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
         if not mo:
-            # unparseable. Maybe git-describe is misbehaving?
+            # unparsable. Maybe git-describe is misbehaving?
             pieces["error"] = ("unable to parse git-describe output: '%s'"
                                % describe_out)
             return pieces

--- a/bids/analysis/hrf.py
+++ b/bids/analysis/hrf.py
@@ -1,5 +1,5 @@
 """
-This module is for hemodynamic reponse function (hrf) specification.
+This module is for hemodynamic response function (hrf) specification.
 Here we provide for SPM, Glover hrfs and finite timpulse response (FIR) models.
 This module closely follows SPM implementation
 
@@ -417,7 +417,7 @@ def compute_regressor(exp_condition, hrf_model, frame_times, con_id='cond',
     oversampling : int, optional
         oversampling factor to perform the convolution
     fir_delays : 1D-array-like, optional
-        delays (in seconds) used in case of a finite impulse reponse model
+        delays (in seconds) used in case of a finite impulse response model
     min_onset : float, optional
         minimal onset relative to frame_times[0] (in seconds)
         events that start before frame_times[0] + min_onset are not considered

--- a/bids/external/inflect.py
+++ b/bids/external/inflect.py
@@ -1802,7 +1802,7 @@ A_abbrev = r"""
 [FHLMNRSX][A-Z]
 """
 
-# THIS PATTERN CODES THE BEGINNINGS OF ALL ENGLISH WORDS BEGINING WITH A
+# THIS PATTERN CODES THE BEGINNINGS OF ALL ENGLISH WORDS BEGINNING WITH A
 # 'y' FOLLOWED BY A CONSONANT. ANY OTHER Y-CONSONANT PREFIX THEREFORE
 # IMPLIES AN ABBREVIATION.
 
@@ -1985,7 +1985,7 @@ class engine:
 
     def defa(self, pattern):
         """
-        Define the indefinate article as 'a' for words matching pattern.
+        Define the indefinite article as 'a' for words matching pattern.
 
         """
         self.checkpat(pattern)
@@ -1994,7 +1994,7 @@ class engine:
 
     def defan(self, pattern):
         """
-        Define the indefinate article as 'an' for words matching pattern.
+        Define the indefinite article as 'an' for words matching pattern.
 
         """
         self.checkpat(pattern)
@@ -2046,7 +2046,7 @@ class engine:
 
         By default all classical modes are off except names.
 
-        unknown value in args or key in kwargs rasies
+        unknown value in args or key in kwargs raises
         exception: UnknownClasicalModeError
 
         """
@@ -3724,7 +3724,7 @@ class engine:
         if finalpoint:
             numchunks.append(decimal)
 
-        # wantlist: Perl list context. can explictly specify in Python
+        # wantlist: Perl list context. can explicitly specify in Python
         if wantlist:
             if sign:
                 numchunks = [sign] + numchunks

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -295,7 +295,7 @@ class BIDSLayout(object):
 
     @classmethod
     def load(cls, database_path):
-        """ Load index from database path. Initalization parameters are set to
+        """ Load index from database path. Initialization parameters are set to
         those found in database_path JSON sidecar.
 
         Parameters

--- a/bids/layout/models.py
+++ b/bids/layout/models.py
@@ -55,7 +55,7 @@ class LayoutInfo(Base):
             setattr(self, col, json.loads(db_val))
 
     def _sanitize_init_args(self, kwargs):
-        """ Prepare initalization arguments for serialization """
+        """ Prepare initialization arguments for serialization """
         if 'root' in kwargs:
             kwargs['root'] = str(Path(kwargs['root']).absolute())
 

--- a/bids/layout/tests/test_writing.py
+++ b/bids/layout/tests/test_writing.py
@@ -170,7 +170,7 @@ sub-{subject}[/ses-{session}]/anat/sub-{subject}[_ses-{session}][_acq-{acquisiti
         assert build_path({'session': 'B', 'run': 3, 'extension': '.nii'},
                           pats) == 'ses-B/r-3.nii'
 
-        # Test default-only patterns are correctly overriden by setting entity
+        # Test default-only patterns are correctly overridden by setting entity
         entities = {
             'subject': '01',
             'extension': 'bvec',

--- a/bids/variables/io.py
+++ b/bids/variables/io.py
@@ -93,7 +93,7 @@ def load_variables(layout, types=None, levels=None, skip_empty=True,
         dataset = _load_time_variables(layout, dataset, scope=scope, **_kwargs)
 
     for t in ({'scans', 'sessions', 'participants'} & set(types)):
-        kwargs.pop('suffix', None) # suffix is always one of values aboves
+        kwargs.pop('suffix', None) # suffix is always one of values above
         dataset = _load_tsv_variables(layout, t, dataset, scope=scope,
                                       **kwargs)
 
@@ -499,7 +499,7 @@ def _load_tsv_variables(layout, suffix, dataset=None, columns=None,
 
         for col_name in amp_cols:
 
-            # Rename colummns: values must be in 'amplitude'
+            # Rename columns: values must be in 'amplitude'
             df = _data.loc[:, [col_name] + ent_cols]
             df.columns = ['amplitude'] + ent_cols
 


### PR DESCRIPTION
but that beast went into fixing some code variables which I decided
would be too much for this one, so just typos in doc/comments for now