### PR TITLE
ENH: Improve `get` performance

### DIFF
--- a/bids/layout/db.py
+++ b/bids/layout/db.py
@@ -79,9 +79,11 @@ class ConnectionManager:
                 'sqlite://',  # In memory database
                 connect_args={'check_same_thread': False},
                 poolclass=StaticPool)
-            
+
         def regexp(expr, item):
             """Regex function for SQLite's REGEXP."""
+            if not isinstance(item, str):
+                return False
             reg = re.compile(expr, re.I)
             return reg.search(item) is not None
 

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -751,18 +751,13 @@ class BIDSLayout(object):
             for name, val in filters.items():
                 tag_alias = aliased(Tag)
 
-                query = query.outerjoin(
-                    tag_alias,
-                    sa.and_(
-                        BIDSFile.path == tag_alias.file_path,
-                        tag_alias.entity_name == name
-                    ),
-                )
-
                 if isinstance(val, (list, tuple)) and len(val) == 1:
                     val = val[0]
 
+                join_method = query.join
+
                 if val is None or val == Query.NONE:
+                    join_method = query.outerjoin
                     val_clause = tag_alias._value.is_(None)
                 elif val == Query.ANY:
                     val_clause = tag_alias._value.isnot(None)
@@ -779,6 +774,14 @@ class BIDSLayout(object):
                         val_clause = tag_alias._value.in_(val)
                     else:
                         val_clause = tag_alias._value == val
+
+                query = join_method(
+                    tag_alias,
+                    sa.and_(
+                        BIDSFile.path == tag_alias.file_path,
+                        tag_alias.entity_name == name
+                    ),
+                )
 
                 query = query.filter(val_clause)
 

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -744,7 +744,6 @@ class BIDSLayout(object):
 
         # Entity filtering
         if filters:
-            # query = query.join(BIDSFile.tags)
             regex = kwargs.get('regex_search', False)
 
             filters = self._sanitize_query_dtypes(filters)

--- a/bids/layout/models.py
+++ b/bids/layout/models.py
@@ -194,7 +194,7 @@ class BIDSFile(Base):
     filename = Column(String)
     dirname = Column(String)
     entities = association_proxy("tags", "value")
-    is_dir = Column(Boolean)
+    is_dir = Column(Boolean, index=True)
     class_ = Column(String(20))
 
     _associations = relationship('BIDSFile', secondary='associations',


### PR DESCRIPTION
Currently, selecting by tags is done using subqueries. For example, using the `get_fieldmap` function leads to the following database query containing three subqueries:
```sql
SELECT files.path, files.filename, files.dirname, files.is_dir, files.class_
FROM files JOIN tags ON files.path = tags.file_path
WHERE files.is_dir = 0 AND (EXISTS (SELECT 1
FROM tags
WHERE files.path = tags.file_path AND tags.entity_name = 'subject' AND (tags._value REGEXP '01'))) AND (EXISTS (SELECT 1
FROM tags
WHERE files.path = tags.file_path AND tags.entity_name = 'suffix' AND (tags._value REGEXP '(phase1|phasediff|epi|fieldmap)'))) AND (EXISTS (SELECT 1
FROM tags
WHERE files.path = tags.file_path AND tags.entity_name = 'extension' AND ((tags._value REGEXP 'nii.gz') OR (tags._value REGEXP 'nii'))))
```

If we use the `EXPLAIN QUERY PLAN` command, we can see that each subquery will be executed once for each entry in the files table, leading to slow performance (this is what `CORRELATED SCALAR SUBQUERY` means, as far as I know).
```
SCAN TABLE tags USING COVERING INDEX sqlite_autoindex_tags_1
SEARCH TABLE files USING INDEX sqlite_autoindex_files_1 (path=?)
CORRELATED SCALAR SUBQUERY 1'
SEARCH TABLE tags USING INDEX sqlite_autoindex_tags_1 (file_path=? AND entity_name=?)
CORRELATED SCALAR SUBQUERY 2
SEARCH TABLE tags USING INDEX sqlite_autoindex_tags_1 (file_path=? AND entity_name=?)
CORRELATED SCALAR SUBQUERY 3
SEARCH TABLE tags USING INDEX sqlite_autoindex_tags_1 (file_path=? AND entity_name=?)
```

I propose to change the `_build_file_query` function to use equi-joins to achieve the same behavior. This way, only one search of the tags table per filter needs to be performed. This idea is based on the following StackOverflow thread <https://stackoverflow.com/questions/30125597/dynamic-columns-in-database-tables-vs-eav/30197015>.
```sql
SELECT files.path, files.filename, files.dirname, files.is_dir, files.class_
FROM files 
LEFT OUTER JOIN tags AS tags_1 ON files.path = tags_1.file_path AND tags_1.entity_name = 'subject' 
LEFT OUTER JOIN tags AS tags_2 ON files.path = tags_2.file_path AND tags_2.entity_name = 'extension' 
LEFT OUTER JOIN tags AS tags_3 ON files.path = tags_3.file_path AND tags_3.entity_name = 'suffix'
WHERE files.is_dir = 0 AND (tags_1._value REGEXP '01') AND ((tags_2._value REGEXP 'nii') OR (tags_2._value REGEXP 'nii.gz')) AND (tags_3._value REGEXP '(phase1|phasediff|epi|fieldmap)') GROUP BY files.path
```
```
SCAN TABLE files USING INDEX sqlite_autoindex_files_1
SEARCH TABLE tags AS tags_1 USING INDEX sqlite_autoindex_tags_1 (file_path=? AND entity_name=?)
SEARCH TABLE tags AS tags_2 USING INDEX sqlite_autoindex_tags_1 (file_path=? AND entity_name=?)
SEARCH TABLE tags AS tags_3 USING INDEX sqlite_autoindex_tags_1 (file_path=? AND entity_name=?)
```

However, I am not sure if there are any edge cases that require the subquery approach. 
