### PR TITLE
Add support for experimental design aggregation

### DIFF
--- a/bids/__init__.py
+++ b/bids/__init__.py
@@ -13,7 +13,8 @@ __all__ = [
     "layout",
     "reports",
     "utils",
-    "variables"
+    "variables",
+    "statsmodels_design_synthesizer",
 ]
 
 due.cite(Doi("10.1038/sdata.2016.44"),

--- a/bids/statsmodels_design_synthesizer.py
+++ b/bids/statsmodels_design_synthesizer.py
@@ -1,0 +1,148 @@
+#! /usr/bin/env python
+import argparse
+import sys
+import json
+from pathlib import Path
+import pandas as pd
+import numpy as np
+from collections import namedtuple
+from bids.modeling import transformations
+from bids.utils import convert_JSON
+from bids.variables import BIDSRunVariableCollection, SparseRunVariable
+from bids.layout.utils import parse_file_entities
+
+
+def statsmodels_design_synthesizer(params):
+    """Console script for bids statsmodels_design_synthesizer."""
+
+    # Output:
+    if not params.get("OUTPUT_DIR"):
+        output_tsv = params.get("OUTPUT_TSV", "aggregated_statsmodels_design.tsv")
+
+    # Sampling rate of output
+    sampling_rate_out = params.get("OUTPUT_SAMPLING_RATE")
+
+    # Process transformations file
+    # TODO: add transforms functionality, for now only model.json is handled
+    # TODO: some basic error checking to confirm the correct level of
+    # transformations has been obtained. This will most likely be the case since
+    # transformations at higher levels will no longer be required when the new
+    # "flow" approach is used.
+    transforms_file = Path(params["TRANSFORMS"])
+    if not transforms_file.exists():
+        raise ValueError(f"Cannot find {transforms_file}")
+    model = convert_JSON(json.loads(model_file.read_text()))
+    model_transforms = model["steps"][0]["transformations"]
+
+    # Get relevant collection
+    coll_df = pd.read_csv(params["EVENTS_TSV"], delimiter="\t")
+    RunInfo = namedtuple("RunInfo", ["entities", "duration"])
+    run_info = RunInfo(parse_file_entities(params["EVENTS_TSV"]), params["DURATION"])
+    coll = get_events_collection(coll_df, [run_info])
+
+    # perform transformations
+    colls = transformations.TransformerManager().transform(coll, model_transforms)
+
+    # Save colls
+    df_out = colls.to_df(sampling_rate=sampling_rate_out)
+    df_out.to_csv(output_tsv, index=None, sep="\t", na_rep="n/a")
+
+
+def get_events_collection(_data, run_info, drop_na=True):
+    """ "
+    This is an attempt to minimally implement:
+    https://github.com/bids-standard/pybids/blob/statsmodels/bids/variables/io.py
+    """
+    colls_output = []
+    if "amplitude" in _data.columns:
+        if (
+            _data["amplitude"].astype(int) == 1
+        ).all() and "trial_type" in _data.columns:
+            msg = (
+                "Column 'amplitude' with constant value 1 "
+                "is unnecessary in event files; ignoring it."
+            )
+            _data = _data.drop("amplitude", axis=1)
+        else:
+            msg = "Column name 'amplitude' is reserved; " "renaming it to 'amplitude_'."
+            _data = _data.rename(columns={"amplitude": "amplitude_"})
+            warnings.warn(msg)
+
+    _data = _data.replace("n/a", np.nan)  # Replace BIDS' n/a
+    _data = _data.apply(pd.to_numeric, errors="ignore")
+
+    _cols = list(set(_data.columns.tolist()) - {"onset", "duration"})
+
+    # Construct a DataFrame for each extra column
+    for col in _cols:
+        df = _data[["onset", "duration"]].copy()
+        df["amplitude"] = _data[col].values
+
+        # Add in all of the run's entities as new columns for
+        # index
+        #        for entity, value in entities.items():
+        #            if entity in ALL_ENTITIES:
+        #                df[entity] = value
+        #
+        if drop_na:
+            df = df.dropna(subset=["amplitude"])
+
+        if df.empty:
+            continue
+        var = SparseRunVariable(name=col, data=df, run_info=run_info, source="events")
+        colls_output.append(var)
+
+    output = BIDSRunVariableCollection(colls_output)
+    return output
+
+
+def create_parser():
+    """Returns argument parser"""
+    p = argparse.ArgumentParser()
+    p.add_argument("--events-tsv", required=True, help="Path to events TSV")
+    p.add_argument(
+        "--transforms", required=True, help="Path to transform or model json"
+    )
+    p.add_argument(
+        "--output-sampling-rate",
+        required=False,
+        help="Output sampling rate in Hz when output is dense instead of sparse",
+    )
+
+    pout = p.add_mutually_exclusive_group()
+    pout.add_argument(
+        "--output-tsv",
+        nargs="?",
+        help="Path to TSV containing a fully constructed design matrix.",
+    )
+    pout.add_argument(
+        "--output-dir",
+        nargs="?",
+        help="Path to directory to write processed event files.",
+    )
+
+    ptimes = p.add_argument_group(
+        "Specify some essential details about the time series."
+    )
+    ptimes.add_argument(
+        "--nvol", required=True, help="Number of volumes in func time-series"
+    )
+    ptimes.add_argument("--tr", required=True, help="TR for func time series")
+    ptimes.add_argument("--ta", required=True, help="TA for events")
+
+    return p
+
+
+def main(user_args=None):
+    parser = create_parser()
+    if user_args is None:
+        namespace = parser.parse_args(sys.argv[1:])
+    else:
+        namespace = parser.parse_args(user_args)
+    params = vars(namespace)
+
+    statsmodels_design_synthesizer(params)
+
+
+if __name__ == "__main__":
+    sys.exit(main())  # pragma: no cover""Main module."""

--- a/bids/statsmodels_design_synthesizer.py
+++ b/bids/statsmodels_design_synthesizer.py
@@ -55,11 +55,11 @@ def statsmodels_design_synthesizer(params):
     coll = get_events_collection(coll_df, run, output='collection')
 
     # perform transformations
-    colls, colls_pre_densifification = transformations.TransformerManager(save_pre_dense=True).transform(coll, model_transforms)
+    colls, colls_pre_densification = transformations.TransformerManager(save_pre_dense=True).transform(coll, model_transforms)
 
     # Save sparse vars
     try:
-        df_sparse = colls_pre_densifification.to_df(include_dense=False)
+        df_sparse = colls_pre_densification.to_df(include_dense=False)
     except AttributeError:
         df_sparse = colls.to_df(include_dense=False)
     df_sparse.to_csv(output_dir / "transformed_events.tsv", index=None, sep="\t", na_rep="n/a")

--- a/bids/statsmodels_design_synthesizer.py
+++ b/bids/statsmodels_design_synthesizer.py
@@ -10,6 +10,8 @@ from bids.modeling import transformations
 from bids.utils import convert_JSON
 from bids.variables import BIDSRunVariableCollection, SparseRunVariable
 from bids.layout.utils import parse_file_entities
+from bids.variables.io import get_events_collection
+from bids.variables.entities import RunNode
 
 
 def statsmodels_design_synthesizer(params):
@@ -47,8 +49,9 @@ def statsmodels_design_synthesizer(params):
     coll_df = pd.read_csv(params["events_tsv"], delimiter="\t")
     RunInfo = namedtuple("RunInfo", ["entities", "duration"])
 
-    run_info = RunInfo(parse_file_entities(params["events_tsv"]), duration)
-    coll = get_events_collection(coll_df, [run_info])
+    #run_info = RunInfo(parse_file_entities(params["events_tsv"]), duration)
+    run = RunNode(parse_file_entities(params["events_tsv"]), None, duration, params["tr"], params["nvol"])
+    coll = get_events_collection(coll_df, run, output='collection')
 
     # perform transformations
     colls = transformations.TransformerManager().transform(coll, model_transforms)
@@ -56,55 +59,6 @@ def statsmodels_design_synthesizer(params):
     # Save colls
     df_out = colls.to_df(sampling_rate=sampling_rate_out)
     df_out.to_csv(output_tsv, index=None, sep="\t", na_rep="n/a")
-
-
-def get_events_collection(_data, run_info, drop_na=True):
-    """ "
-    This is an attempt to minimally implement:
-    https://github.com/bids-standard/pybids/blob/statsmodels/bids/variables/io.py
-    """
-    colls_output = []
-    if "amplitude" in _data.columns:
-        if (
-            _data["amplitude"].astype(int) == 1
-        ).all() and "trial_type" in _data.columns:
-            msg = (
-                "Column 'amplitude' with constant value 1 "
-                "is unnecessary in event files; ignoring it."
-            )
-            _data = _data.drop("amplitude", axis=1)
-        else:
-            msg = "Column name 'amplitude' is reserved; " "renaming it to 'amplitude_'."
-            _data = _data.rename(columns={"amplitude": "amplitude_"})
-            warnings.warn(msg)
-
-    _data = _data.replace("n/a", np.nan)  # Replace BIDS' n/a
-    _data = _data.apply(pd.to_numeric, errors="ignore")
-
-    _cols = list(set(_data.columns.tolist()) - {"onset", "duration"})
-
-    # Construct a DataFrame for each extra column
-    for col in _cols:
-        df = _data[["onset", "duration"]].copy()
-        df["amplitude"] = _data[col].values
-
-        # Add in all of the run's entities as new columns for
-        # index
-        #        for entity, value in entities.items():
-        #            if entity in ALL_ENTITIES:
-        #                df[entity] = value
-        #
-        if drop_na:
-            df = df.dropna(subset=["amplitude"])
-
-        if df.empty:
-            continue
-        var = SparseRunVariable(name=col, data=df, run_info=run_info, source="events")
-        colls_output.append(var)
-
-    output = BIDSRunVariableCollection(colls_output)
-    return output
-
 
 def create_parser():
     """Returns argument parser"""

--- a/bids/statsmodels_design_synthesizer.py
+++ b/bids/statsmodels_design_synthesizer.py
@@ -66,14 +66,14 @@ def statsmodels_design_synthesizer(params):
     # Save dense vars
     try:
         df_dense = colls.to_df(include_sparse=False)
-        df_out.to_csv(output_dir / "transformed_time_series.tsv", index=None, sep="\t", na_rep="n/a")
+        df_dense.to_csv(output_dir / "transformed_time_series.tsv", index=None, sep="\t", na_rep="n/a")
     except ValueError:
         pass
 
     # Save full design_matrix
     if sampling_rate_out:
         df_full = colls.to_df(sampling_rate=sampling_rate_out)
-        df_out.to_csv(output_dir / "aggregated_design.tsv", index=None, sep="\t", na_rep="n/a")
+        df_full.to_csv(output_dir / "aggregated_design.tsv", index=None, sep="\t", na_rep="n/a")
 
 def create_parser():
     """Returns argument parser"""

--- a/bids/statsmodels_design_synthesizer.py
+++ b/bids/statsmodels_design_synthesizer.py
@@ -19,6 +19,8 @@ def statsmodels_design_synthesizer(params):
 
     # Sampling rate of output
     sampling_rate_out = params.get("output_sampling_rate")
+    output_dir = Path(params.get("output_dir", 'design_synthesizer'))
+    output_dir.mkdir(exist_ok=True) 
 
     # Process transformations file
     # TODO: abstact transforms file reading into a function.
@@ -56,11 +58,17 @@ def statsmodels_design_synthesizer(params):
     colls, colls_pre_densifification = transformations.TransformerManager(save_pre_dense=True).transform(coll, model_transforms)
 
     # Save sparse vars
-    df_sparse = colls_pre_densifification.to_df(include_dense=False)
+    try:
+        df_sparse = colls_pre_densifification.to_df(include_dense=False)
+    except AttributeError:
+        df_sparse = colls.to_df(include_dense=False)
     df_sparse.to_csv(output_dir / "transformed_events.tsv", index=None, sep="\t", na_rep="n/a")
     # Save dense vars
-    df_dense = colls.to_df(include_sparse=False)
-    df_out.to_csv(output_dir / "transformed_time_series.tsv", index=None, sep="\t", na_rep="n/a")
+    try:
+        df_dense = colls.to_df(include_sparse=False)
+        df_out.to_csv(output_dir / "transformed_time_series.tsv", index=None, sep="\t", na_rep="n/a")
+    except ValueError:
+        pass
 
     # Save full design_matrix
     if sampling_rate_out:

--- a/bids/statsmodels_design_synthesizer.py
+++ b/bids/statsmodels_design_synthesizer.py
@@ -58,6 +58,10 @@ def statsmodels_design_synthesizer(params):
     colls, colls_pre_densification = transformations.TransformerManager(save_pre_dense=True).transform(coll, model_transforms)
 
     # Save sparse vars
+    # TODO: consider cases where dense/sparse changes from transformation but
+    # sparse vars need to be combined between pre_densification and post
+    # transformation
+    # i.e. list(colls.variables.keys()) != [x.name for x in colls.get_sparse_variables()]
     try:
         df_sparse = colls_pre_densification.to_df(include_dense=False)
     except AttributeError:

--- a/bids/statsmodels_design_synthesizer.py
+++ b/bids/statsmodels_design_synthesizer.py
@@ -25,6 +25,7 @@ def statsmodels_design_synthesizer(params):
     sampling_rate_out = params.get("output_sampling_rate")
 
     # Process transformations file
+    # TODO: abstact transforms file reading into a function.
     # TODO: add transforms functionality, for now only model.json is handled
     # TODO: some basic error checking to confirm the correct level of
     # transformations has been obtained. This will most likely be the case since
@@ -50,6 +51,8 @@ def statsmodels_design_synthesizer(params):
     RunInfo = namedtuple("RunInfo", ["entities", "duration"])
 
     #run_info = RunInfo(parse_file_entities(params["events_tsv"]), duration)
+    # TODO: this will need to be implemented without RunNode to break cyclic
+    # dependencies if transformations is to be extracted
     run = RunNode(parse_file_entities(params["events_tsv"]), None, duration, params["tr"], params["nvol"])
     coll = get_events_collection(coll_df, run, output='collection')
 

--- a/bids/tests/test_statsmodels-design-synthesizer.py
+++ b/bids/tests/test_statsmodels-design-synthesizer.py
@@ -35,12 +35,24 @@ def test_cli_help():
         output = sp.check_output([SYNTHESIZER, "--non-existent"])
 
 
-def test_design_aggregation_function():
+@pytest.mark.parametrize(
+    "test_case,user_args",
+    [
+        ("Model type test", EXAMPLE_USER_ARGS),
+        ("Model type mfx", EXAMPLE_USER_ARGS_2),
+    ]
+)
+def test_design_aggregation_function(test_case,user_args):
     synth_mod.main(EXAMPLE_USER_ARGS)
-    synth_mod.main(EXAMPLE_USER_ARGS_2)
 
-
-def test_minimal_cli_functionality():
+@pytest.mark.parametrize(
+    "test_case,user_args",
+    [
+        ("Model type test", EXAMPLE_USER_ARGS),
+        ("Model type mfx", EXAMPLE_USER_ARGS_2),
+    ]
+)
+def test_minimal_cli_functionality(test_case,user_args):
     """
     We roughly want to implement the equivalent of the following:
     from bids.analysis import Analysis
@@ -53,11 +65,8 @@ def test_minimal_cli_functionality():
     more specifically we want to reimplement this line
     https://github.com/bids-standard/pybids/blob/b6cd0f6787230ce976a374fbd5fce650865752a3/bids/analysis/analysis.py#L282
     """
-    arg_list = " " .join([f"""--{k.lower().replace("_","-")}={v}""" for k,v in EXAMPLE_USER_ARGS.items()])
+    arg_list = " " .join([f"""--{k.lower().replace("_","-")}={v}""" for k,v in user_args.items()])
     cmd = f"{SYNTHESIZER} {arg_list}"
     output = sp.check_output(cmd.split())
 
-    arg_list = " " .join([f"""--{k.lower().replace("_","-")}={v}""" for k,v in EXAMPLE_USER_ARGS_2.items()])
-    cmd = f"{SYNTHESIZER} {arg_list}"
-    output = sp.check_output(cmd.split())
 

--- a/bids/tests/test_statsmodels-design-synthesizer.py
+++ b/bids/tests/test_statsmodels-design-synthesizer.py
@@ -27,6 +27,7 @@ EXAMPLE_USER_ARGS_2 = {
         "tr": 2,
         "ta": 2,
         "nvol": 160,
+        "output_sampling_rate":10,
     }
 
 def test_cli_help():

--- a/bids/tests/test_statsmodels-design-synthesizer.py
+++ b/bids/tests/test_statsmodels-design-synthesizer.py
@@ -46,7 +46,7 @@ def test_cli_help():
 )
 def test_design_aggregation_function(tmp_path,test_case,user_args):
     user_args['output_dir'] = str(tmp_path)
-    synth_mod.main(EXAMPLE_USER_ARGS)
+    synth_mod.main(user_args)
 
 @pytest.mark.parametrize(
     "test_case,user_args",

--- a/bids/tests/test_statsmodels-design-synthesizer.py
+++ b/bids/tests/test_statsmodels-design-synthesizer.py
@@ -5,6 +5,7 @@
 import pytest
 import subprocess as sp
 from pathlib import Path
+import tempfile
 
 SYNTHESIZER = "statsmodels-design-synthesizer"
 from bids import statsmodels_design_synthesizer as synth_mod
@@ -12,7 +13,7 @@ from bids import statsmodels_design_synthesizer as synth_mod
 # from bids_statsmodels_design_synthesizer import Path(SYNTHESIZER).stem as synth_mod
 DATA_DIR = (Path(__file__).parent / "data/ds005").absolute()
 EXAMPLE_USER_ARGS = {
-        "output_tsv": "aggregated_design.tsv",
+        "output_dir": tempfile.TemporaryDirectory().name,
         "transforms": f"{DATA_DIR}/models/ds-005_type-mfx_model.json",
         "events_tsv": f"{DATA_DIR}/sub-01/func/sub-01_task-mixedgamblestask_run-01_events.tsv",
         "tr": 2,

--- a/bids/tests/test_statsmodels-design-synthesizer.py
+++ b/bids/tests/test_statsmodels-design-synthesizer.py
@@ -7,22 +7,21 @@ import subprocess as sp
 from pathlib import Path
 
 SYNTHESIZER = "statsmodels-design-synthesizer"
-from bids.statsmodels_design_synthesizer import statsmodels_design_synthesizer as synth_mod
+from bids import statsmodels_design_synthesizer as synth_mod
 
 # from bids_statsmodels_design_synthesizer import Path(SYNTHESIZER).stem as synth_mod
 EXAMPLE_USER_ARGS = {
-        "OUTPUT_TSV": "aggregated_design.tsv",
-        "TRANSFORMS": "data/ds005/models/ds-005_type-mfx_model.json",
-        "EVENTS_TSV": "data/ds005/sub-01/func/sub-01_task-mixedgamblestask_run-01_events.tsv",
-        "TR": 2,
-        "TA": 2,
-        "NVOLS": 160,
+        "output_tsv": "aggregated_design.tsv",
+        "transforms": "data/ds005/models/ds-005_type-mfx_model.json",
+        "events_tsv": "data/ds005/sub-01/func/sub-01_task-mixedgamblestask_run-01_events.tsv",
+        "tr": 2,
+        "ta": 2,
+        "nvol": 160,
     }
 
 
 def test_cli_help():
-    with pytest.raises(sp.CalledProcessError):
-        output = sp.check_output([SYNTHESIZER, "-h"])
+    output = sp.check_output([SYNTHESIZER, "-h"])
     with pytest.raises(sp.CalledProcessError):
         output = sp.check_output([SYNTHESIZER, "--non-existent"])
 
@@ -44,8 +43,6 @@ def test_minimal_cli_functionality():
     more specifically we want to reimplement this line
     https://github.com/bids-standard/pybids/blob/b6cd0f6787230ce976a374fbd5fce650865752a3/bids/analysis/analysis.py#L282
     """
-    bids_dir = Path(__file__).parent / "data/ds000003"
-    model = "model-001_smdl.json"
     arg_list = " " .join([f"""--{k.lower().replace("_","-")}={v}""" for k,v in EXAMPLE_USER_ARGS.items()])
     cmd = f"{SYNTHESIZER} {arg_list}"
     output = sp.check_output(cmd.split())

--- a/bids/tests/test_statsmodels-design-synthesizer.py
+++ b/bids/tests/test_statsmodels-design-synthesizer.py
@@ -12,8 +12,10 @@ from bids import statsmodels_design_synthesizer as synth_mod
 
 # from bids_statsmodels_design_synthesizer import Path(SYNTHESIZER).stem as synth_mod
 DATA_DIR = (Path(__file__).parent / "data/ds005").absolute()
+
+# Define some example user arg combinations (without output_dir which is better
+# to define in the scope of the test)
 EXAMPLE_USER_ARGS = {
-        "output_dir": tempfile.TemporaryDirectory().name,
         "transforms": f"{DATA_DIR}/models/ds-005_type-mfx_model.json",
         "events_tsv": f"{DATA_DIR}/sub-01/func/sub-01_task-mixedgamblestask_run-01_events.tsv",
         "tr": 2,
@@ -21,7 +23,6 @@ EXAMPLE_USER_ARGS = {
         "nvol": 160,
     }
 EXAMPLE_USER_ARGS_2 = {
-        "output_dir": tempfile.TemporaryDirectory().name,
         "transforms": f"{DATA_DIR}/models/ds-005_type-test_model.json",
         "events_tsv": f"{DATA_DIR}/sub-01/func/sub-01_task-mixedgamblestask_run-01_events.tsv",
         "tr": 2,
@@ -43,7 +44,8 @@ def test_cli_help():
         ("Model type mfx", EXAMPLE_USER_ARGS_2),
     ]
 )
-def test_design_aggregation_function(test_case,user_args):
+def test_design_aggregation_function(tmp_path,test_case,user_args):
+    user_args['output_dir'] = str(tmp_path)
     synth_mod.main(EXAMPLE_USER_ARGS)
 
 @pytest.mark.parametrize(
@@ -53,7 +55,7 @@ def test_design_aggregation_function(test_case,user_args):
         ("Model type mfx", EXAMPLE_USER_ARGS_2),
     ]
 )
-def test_minimal_cli_functionality(test_case,user_args):
+def test_minimal_cli_functionality(tmp_path,test_case,user_args):
     """
     We roughly want to implement the equivalent of the following:
     from bids.analysis import Analysis
@@ -66,6 +68,7 @@ def test_minimal_cli_functionality(test_case,user_args):
     more specifically we want to reimplement this line
     https://github.com/bids-standard/pybids/blob/b6cd0f6787230ce976a374fbd5fce650865752a3/bids/analysis/analysis.py#L282
     """
+    user_args['output_dir'] = str(tmp_path)
     arg_list = " " .join([f"""--{k.lower().replace("_","-")}={v}""" for k,v in user_args.items()])
     cmd = f"{SYNTHESIZER} {arg_list}"
     output = sp.check_output(cmd.split())

--- a/bids/tests/test_statsmodels-design-synthesizer.py
+++ b/bids/tests/test_statsmodels-design-synthesizer.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+
+"""Tests for `bids_statsmodels_design_synthesizer` package."""
+
+import pytest
+import subprocess as sp
+from pathlib import Path
+
+SYNTHESIZER = "statsmodels-design-synthesizer"
+from bids.statsmodels_design_synthesizer import statsmodels_design_synthesizer as synth_mod
+
+# from bids_statsmodels_design_synthesizer import Path(SYNTHESIZER).stem as synth_mod
+EXAMPLE_USER_ARGS = {
+        "OUTPUT_TSV": "aggregated_design.tsv",
+        "TRANSFORMS": "data/ds005/models/ds-005_type-mfx_model.json",
+        "EVENTS_TSV": "data/ds005/sub-01/func/sub-01_task-mixedgamblestask_run-01_events.tsv",
+        "TR": 2,
+        "TA": 2,
+        "NVOLS": 160,
+    }
+
+
+def test_cli_help():
+    with pytest.raises(sp.CalledProcessError):
+        output = sp.check_output([SYNTHESIZER, "-h"])
+    with pytest.raises(sp.CalledProcessError):
+        output = sp.check_output([SYNTHESIZER, "--non-existent"])
+
+
+def test_design_aggregation_function():
+    synth_mod.main(EXAMPLE_USER_ARGS)
+
+
+def test_minimal_cli_functionality():
+    """
+    We roughly want to implement the equivalent of the following:
+    from bids.analysis import Analysis
+    from bids.layout import BIDSLayout
+
+    layout = BIDSLayout("data/ds000003")
+    analysis = Analysis(model="data/ds000003/models/model-001_smdl.json",layout=layout)
+    analysis.setup()
+
+    more specifically we want to reimplement this line
+    https://github.com/bids-standard/pybids/blob/b6cd0f6787230ce976a374fbd5fce650865752a3/bids/analysis/analysis.py#L282
+    """
+    bids_dir = Path(__file__).parent / "data/ds000003"
+    model = "model-001_smdl.json"
+    arg_list = " " .join([f"""--{k.lower().replace("_","-")}={v}""" for k,v in EXAMPLE_USER_ARGS.items()])
+    cmd = f"{SYNTHESIZER} {arg_list}"
+    output = sp.check_output(cmd.split())
+

--- a/bids/tests/test_statsmodels-design-synthesizer.py
+++ b/bids/tests/test_statsmodels-design-synthesizer.py
@@ -20,7 +20,14 @@ EXAMPLE_USER_ARGS = {
         "ta": 2,
         "nvol": 160,
     }
-
+EXAMPLE_USER_ARGS_2 = {
+        "output_dir": tempfile.TemporaryDirectory().name,
+        "transforms": f"{DATA_DIR}/models/ds-005_type-test_model.json",
+        "events_tsv": f"{DATA_DIR}/sub-01/func/sub-01_task-mixedgamblestask_run-01_events.tsv",
+        "tr": 2,
+        "ta": 2,
+        "nvol": 160,
+    }
 
 def test_cli_help():
     output = sp.check_output([SYNTHESIZER, "-h"])
@@ -30,6 +37,7 @@ def test_cli_help():
 
 def test_design_aggregation_function():
     synth_mod.main(EXAMPLE_USER_ARGS)
+    synth_mod.main(EXAMPLE_USER_ARGS_2)
 
 
 def test_minimal_cli_functionality():
@@ -46,6 +54,10 @@ def test_minimal_cli_functionality():
     https://github.com/bids-standard/pybids/blob/b6cd0f6787230ce976a374fbd5fce650865752a3/bids/analysis/analysis.py#L282
     """
     arg_list = " " .join([f"""--{k.lower().replace("_","-")}={v}""" for k,v in EXAMPLE_USER_ARGS.items()])
+    cmd = f"{SYNTHESIZER} {arg_list}"
+    output = sp.check_output(cmd.split())
+
+    arg_list = " " .join([f"""--{k.lower().replace("_","-")}={v}""" for k,v in EXAMPLE_USER_ARGS_2.items()])
     cmd = f"{SYNTHESIZER} {arg_list}"
     output = sp.check_output(cmd.split())
 

--- a/bids/tests/test_statsmodels-design-synthesizer.py
+++ b/bids/tests/test_statsmodels-design-synthesizer.py
@@ -10,10 +10,11 @@ SYNTHESIZER = "statsmodels-design-synthesizer"
 from bids import statsmodels_design_synthesizer as synth_mod
 
 # from bids_statsmodels_design_synthesizer import Path(SYNTHESIZER).stem as synth_mod
+DATA_DIR = (Path(__file__).parent / "data/ds005").absolute()
 EXAMPLE_USER_ARGS = {
         "output_tsv": "aggregated_design.tsv",
-        "transforms": "data/ds005/models/ds-005_type-mfx_model.json",
-        "events_tsv": "data/ds005/sub-01/func/sub-01_task-mixedgamblestask_run-01_events.tsv",
+        "transforms": f"{DATA_DIR}/models/ds-005_type-mfx_model.json",
+        "events_tsv": f"{DATA_DIR}/sub-01/func/sub-01_task-mixedgamblestask_run-01_events.tsv",
         "tr": 2,
         "ta": 2,
         "nvol": 160,

--- a/bids/variables/io.py
+++ b/bids/variables/io.py
@@ -216,14 +216,13 @@ def get_regressors_collection(_data, run, columns=None, entities=None, output='r
         return BIDSRunVariableCollection(colls_output)
 
 
-def get_rec_collection(rec_file,run,metadata,run_info=None,columns=None,entities=None, output='run'):
+def get_rec_collection(data,run,metadata,source,run_info=None,columns=None,entities=None, output='run'):
 
     if output == 'collection':
         colls_output = []
     elif output != 'run':
         raise ValueError(f"output must be one of [run, output], {output} was passed.")
 
-    data = pd.read_csv(rec_file, sep='\t')
     if output == 'collection':
         colls_output = []
     elif output != 'run':
@@ -267,7 +266,6 @@ def get_rec_collection(rec_file,run,metadata,run_info=None,columns=None,entities
         values = np.r_[values, pad]
 
     df = pd.DataFrame(values, columns=rf_cols)
-    source = 'physio' if '_physio.tsv' in rec_file else 'stim'
     for col in df.columns:
         var = DenseRunVariable(name=col, values=df[[col]], run_info=run_info,
                                source=source, sampling_rate=freq)
@@ -451,7 +449,15 @@ def _load_time_variables(layout, dataset=None, columns=None, scan_length=None,
                 if not metadata:
                     raise ValueError("No .json sidecar found for '%s'." % rf)
                 # rec_file passed in for now because rec_type needs to be inferred
-                run = get_rec_collection(rf, run, metadata, run_info=run_info, columns=columns)
+                source = 'physio' if '_physio.tsv' in rf else 'stim'
+                data = pd.read_csv(rf, sep='\t')
+                run = get_rec_collection(
+                                         data,
+                                         run,
+                                         metadata,
+                                         source,
+                                         run_info=run_info,
+                                         columns=columns)
 
     return dataset
 

--- a/bids/variables/io.py
+++ b/bids/variables/io.py
@@ -199,7 +199,6 @@ def get_regressors_collection(_data, run, columns=None, entities=None, output='r
         conf_cols = list(set(_data.columns) & set(columns))
         _data = _data.loc[:, conf_cols]
     for col in _data.columns:
-        # TODO: output sampling rate should likely be used
         sr = 1. / run.repetition_time
         var = DenseRunVariable(name=col, values=_data[[col]],
                        run_info=run_info, source='regressors',

--- a/bids/variables/io.py
+++ b/bids/variables/io.py
@@ -185,7 +185,6 @@ def get_events_collection(_data, run, drop_na=True, columns=None, entities=None,
 
 
 def get_regressors_collection(_data, run, columns=None, entities=None, output='run'):
-    # TODO: is drop na functionality required?
     if output == 'collection':
         colls_output = []
     elif output != 'run':

--- a/bids/variables/io.py
+++ b/bids/variables/io.py
@@ -320,6 +320,7 @@ def _load_time_variables(layout, dataset=None, columns=None, scan_length=None,
                 img_f, extension='.tsv', suffix='events', all_=True,
                 full_search=True, ignore_strict_entities=['suffix', 'extension'])
             for _data in dfs:
+                _data = pd.read_csv(_data, sep='\t')
                 run = get_events_collection(_data, run, entities)
 
         # Process confound files

--- a/bids/variables/io.py
+++ b/bids/variables/io.py
@@ -120,7 +120,7 @@ def _get_nvols(img_f):
 
     return nvols
 
-def get_events_collection(_data, run, entities=None, drop_na=True, output='run', columns=None):
+def get_events_collection(_data, run, drop_na=True, columns=None, entities=None, output='run'):
     """
     This is an attempt to minimally implement:
     https://github.com/bids-standard/pybids/blob/statsmodels/bids/variables/io.py
@@ -316,12 +316,12 @@ def _load_time_variables(layout, dataset=None, columns=None, scan_length=None,
 
         # Process event files
         if events:
-            dfs = layout.get_nearest(
+            efiles = layout.get_nearest(
                 img_f, extension='.tsv', suffix='events', all_=True,
                 full_search=True, ignore_strict_entities=['suffix', 'extension'])
-            for _data in dfs:
-                _data = pd.read_csv(_data, sep='\t')
-                run = get_events_collection(_data, run, entities)
+            for ef in efiles:
+                _data = pd.read_csv(ef, sep='\t')
+                run = get_events_collection(_data, run, drop_na=drop_na, columns=columns)
 
         # Process confound files
         if regressors:

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,7 @@ dev =
 [options.entry_points]
 console_scripts =
     pybids=bids.cli:cli
+    statsmodels-design-synthesizer=bids.statsmodels_design_synthesizer:main
 
 [versioneer]
 VCS = git


### PR DESCRIPTION
@effigies, @tyarkoni  

Overall this looks like a nice way to support downstream users of the stats-model spec. @Shotgunosine and myself have implemented a simple command line tool that, for a given bids run (I likely mean something more precise like combination of factor levels at the first-level modeling), writes out the appropriate transformed variables (dense and sparse) of the design matrix to tsv files as well as the fully assembled design matrix (currently using the pybids HRF for convolution). In summary, this a CLI that wraps the transformations logic of pybids; pybids will continue to directly access said logic using python to reduce file IO.

```
$ statsmodels-design-synthesizer -h
usage: statsmodels-design-synthesizer [-h] --events-tsv EVENTS_TSV --transforms TRANSFORMS [--output-sampling-rate OUTPUT_SAMPLING_RATE] --output-dir OUTPUT_DIR --nvol NVOL --tr TR --ta TA

optional arguments:
  -h, --help            show this help message and exit
  --events-tsv EVENTS_TSV
                        Path to events TSV
  --transforms TRANSFORMS
                        Path to transform or model json
  --output-sampling-rate OUTPUT_SAMPLING_RATE
                        Output sampling rate in Hz when a full design matrix is desired.
  --output-dir OUTPUT_DIR
                        Path to directory to write processed event files.

Specify some essential details about the time series.:
  --nvol NVOL           Number of volumes in func time-series
  --tr TR               TR for func time series
  --ta TA               TA for events
```

Our [external prototype](https://github.com/bids-standard/bids-statsmodels-design-synthesizer) (which extracted the time series transformation logic of pybids) revealed some dependence on bids variables/variable collections that makes that option impossible for now (it would result in cyclic import dependencies). If it is reasonable to pull the above classes along with the transformations modules, a hypothetical standalone package could be called bids-timeseries or something like that and provide a way of doing transformations with the various experimental time-series without the bids entities/metadata collection logic of pybids. Such encapsulation could conceivably be valuable. This would be a longer term goal and external contributors would likely be needed to drop the dependencies of such a package though (numpy and pandas currently making the required time-series operations a lot easier than using the python standard library... resampling time series, convolutions etc would be unpleasant to write from scratch). @afni-rickr thoughts/burning desire to contribute said lower level implementation welcome.


Myself and @shotgunosine are going to make a final push on this today. Any feedback would be much appreciated. Here's the current TODO list.

Feedback would be most valuable here:
- [ ] Decide upon a name. Suggestions [here](https://github.com/bids-standard/bids-statsmodels-design-synthesizer/issues/3)
- [ ] Confirm args for CLI... @effigies felt TR/TA would be best for supporting future functionality. Also passing nvol explicitly rather than parsing it from the image will drop nibabel as a future requirement. Overall stable CLI should be prioritized over parsimony/convenience for interactive use.
- [ ] Provide some example invocations where third party tools are used for convolution with a HRF (might be better implemented as a test within fitlins)
- [ ] Consider adding to_afni/to_fsl methods etc to the bids variable collection class  instead of dumping the sparse/variables to tsvs. For now I think the tsvs are a reasonable intermediate for the downstream implementers to target. Sparse/dense tsv combination can be used if package specific convolution with HRFs etc are desired, otherwise the fully constructed design matrix can be mapped to the appropriate downstream format e.g. 3dremlfit [compatible design matrix](https://github.com/poldracklab/fitlins/blob/b55d28599efc28c9b0e08a797e3ebfb328e13367/fitlins/interfaces/afni.py#L365)
- [ ] We initially used  a [named tuple for  run info](https://github.com/bids-standard/pybids/blob/76c0c5476152a77229c951cc0aede1500ca2dfd0/bids/statsmodels_design_synthesizer.py#L51) during collection construction. This effectively drives to logical flows through the bids variable loading (in io.py). It seems the RunNode class should be left in pybids in which case we would need to use the collections code path... it would be nice to implemented this in a less hacky way...
 
Some other implementation details that we can handle:
- [ ] Confirm/add support for dense/sparse blends pre/post transforms (see [here](https://github.com/bids-standard/pybids/blob/76c0c5476152a77229c951cc0aede1500ca2dfd0/bids/statsmodels_design_synthesizer.py#L61))
- [ ] Add support for parsing a transform json instead of just a model json.
- [ ] Switch to click for CLI
- [ ] Rebase onto statsmodels branch until it is merged
