### PR TITLE
MNT: Set minimum version to Python 3.6

### DIFF
--- a/bids/layout/tests/test_db.py
+++ b/bids/layout/tests/test_db.py
@@ -1,14 +1,10 @@
 """Test functionality in the db module--mostly related to connection
 management."""
 
-import re
-from pathlib import Path
-
 from bids.layout.db import (ConnectionManager, get_database_file)
 
 
 def test_get_database_file(tmp_path):
-    tmp_path = Path(str(tmp_path))  # PY35: pytest uses pathlib2.Path; __fspath__ in Python 3.6 fixes this
     assert get_database_file(None) is None
     new_path = tmp_path / "a_new_subdir"
     assert not new_path.exists()

--- a/bids/layout/tests/test_models.py
+++ b/bids/layout/tests/test_models.py
@@ -276,7 +276,6 @@ def test_bidsfile_relpath(layout_synthetic):
     assert bf.relpath == str(Path(bf.path).relative_to(layout_synthetic.root))
 
 
-@pytest.mark.xfail(sys.version_info < (3, 6), reason="os.PathLike introduced in Python 3.6")
 def test_bidsfile_fspath(sample_bidsfile):
     bf = sample_bidsfile
     bf_path = Path(bf)

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ classifiers =
     Topic :: Scientific/Engineering
 
 [options]
-python_requires = >=3.5
+python_requires = >=3.6
 install_requires =
     numpy
     scipy
@@ -34,7 +34,6 @@ install_requires =
 tests_require =
     pytest >=3.3
     mock
-    pathlib ; python_version < "3.4"
 packages = find:
 include_package_data = True
 


### PR DESCRIPTION
Left this off so long, we're almost ready to to drop 3.6...

Anyway, we haven't tested on 3.5 for a bit, and it's EOL, so let's just turn the crank.

Closes #666.