### PR TITLE
FIX: ensure force_dense=True runs to_dense only on sparse variables

### DIFF
--- a/bids/modeling/statsmodels.py
+++ b/bids/modeling/statsmodels.py
@@ -649,9 +649,7 @@ class BIDSStatsModelsNodeOutput:
             # takes extra arguments related to handling of time
             if level == 'run':
                 if self.force_dense:
-                    sparse_names = [s.name for s in coll.get_sparse_variables()]
-                    if sparse_names:
-                        coll = coll.to_dense(variables=sparse_names, sampling_rate=self.sampling_rate)
+                    coll = coll.to_dense(sampling_rate=self.sampling_rate)
                 coll = coll.to_df(sampling_rate=self.sampling_rate)
             else:
                 coll = coll.to_df()

--- a/bids/modeling/statsmodels.py
+++ b/bids/modeling/statsmodels.py
@@ -649,7 +649,9 @@ class BIDSStatsModelsNodeOutput:
             # takes extra arguments related to handling of time
             if level == 'run':
                 if self.force_dense:
-                    coll = coll.to_dense(sampling_rate=self.sampling_rate)
+                    sparse_names = [s.name for s in coll.get_sparse_variables()]
+                    if sparse_names:
+                        coll = coll.to_dense(variables=sparse_names, sampling_rate=self.sampling_rate)
                 coll = coll.to_df(sampling_rate=self.sampling_rate)
             else:
                 coll = coll.to_df()

--- a/bids/variables/collections.py
+++ b/bids/variables/collections.py
@@ -434,6 +434,10 @@ class BIDSRunVariableCollection(BIDSVariableCollection):
             for v in _dense:
                 _variables[v.name] = v.resample(sr_arg, kind=kind)
 
+        for v in _dense:
+            if v.name not in _variables:
+                _variables[v.name] = v
+
         coll = self if in_place else self.clone()
 
         if in_place:
@@ -445,7 +449,7 @@ class BIDSRunVariableCollection(BIDSVariableCollection):
         return coll
 
     def to_dense(
-        self, sampling_rate=None, variables=None, in_place=False, kind="linear"
+        self, sampling_rate=None, variables=None, in_place=False, resample_dense=False, kind="linear"
     ):
         """Convert all contained SparseRunVariables to DenseRunVariables.
 
@@ -479,7 +483,7 @@ class BIDSRunVariableCollection(BIDSVariableCollection):
         return self._densify_and_resample(
             sampling_rate,
             variables,
-            resample_dense=False,
+            resample_dense=resample_dense,
             in_place=in_place,
             kind=kind,
             force_dense=True,


### PR DESCRIPTION
Currently the `force_dense=True` forces `to_dense` on all variables of the collection even when they are all instances of `DenseRunVariable`. This fix ensures that `to_dense` is run only on sparse variables.

cc: @effigies 