### PR TITLE
FIX: get unique, with conflicting meta-data

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -678,7 +678,9 @@ class BIDSLayout(object):
             results = [x for x in results if target in x.entities]
 
             if return_type == 'id':
-                results = list(set([x.entities[target] for x in results]))
+                results = list(set(
+                    [x.entities[target] for x in results 
+                     if type(x.entities[target]) is not dict]))
                 results = natural_sort(results)
 
             elif return_type == 'dir':


### PR DESCRIPTION
Fixes #747 

This is a cheap fix for a bug that occurs when a `.tsv` meta-data entry (i.e. column description) matches a common BIDS entity.

For example, if you call `layout.get_tasks()`, it will first get all unique values for the `task` entity. However, if `index_metadata=True`, that includes all instances of `task` in `.json` sidecars for TSVs as well. However, `.json` sidecars for `.tsv` files are a different type of meta-data that describes the columns in TSV files, not the entities of the corresponding file. 

Thus, `get_tasks` will fail because it tries to take a set on a list that includes a `dict` value. Here, I simply excluded dict values from that operation.