### PR TITLE
FIX: Associate "is_metadata" with Tag, not Entity; and only return non-metadata entries for core Entities in get(return_type='id')

### DIFF
--- a/bids/layout/index.py
+++ b/bids/layout/index.py
@@ -445,9 +445,9 @@ class BIDSLayoutIndexer:
                             md_val))
                     continue
                 if md_key not in all_entities:
-                    all_entities[md_key] = Entity(md_key, is_metadata=True)
+                    all_entities[md_key] = Entity(md_key)
                     self.session.add(all_entities[md_key])
-                tag = Tag(bf, all_entities[md_key], md_val)
+                tag = Tag(bf, all_entities[md_key], md_val, is_metadata=True)
                 self.session.add(tag)
 
             if len(self.session.new) >= 1000:

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -296,7 +296,7 @@ class BIDSLayout(object):
 
     @classmethod
     def load(cls, database_path):
-        """ Load index from database path. Initiget_entitiesalization parameters are set to
+        """ Load index from database path. Initialization parameters are set to
         those found in database_path JSON sidecar.
 
         Parameters

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -879,7 +879,7 @@ class BIDSLayout(object):
                      .filter(BIDSFile.path == path))
 
             if not include_entities:
-                query = query.join(Entity).join(Tag).filter(Tag.is_metadata == True)
+                query = query.join(Entity).filter(Tag.is_metadata == True)
 
             results = query.all()
             if results:

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -296,7 +296,7 @@ class BIDSLayout(object):
 
     @classmethod
     def load(cls, database_path):
-        """ Load index from database path. Initialization parameters are set to
+        """ Load index from database path. Initiget_entitiesalization parameters are set to
         those found in database_path JSON sidecar.
 
         Parameters
@@ -313,7 +313,7 @@ class BIDSLayout(object):
 
         Note: This is only necessary if a database_path was not specified
         at initialization, and the user now wants to save the index.
-        If a database_path was specified originally, there is no need to
+        If a database_path was specified originaquery = l.session.query(Entity)lly, there is no need to
         re-save using this method.
 
         Parameters
@@ -369,7 +369,7 @@ class BIDSLayout(object):
         for l in layouts:
             query = l.session.query(Entity)
             if metadata is not None:
-                query = query.filter_by(is_metadata=metadata)
+                query = query.join(Tag).filter_by(is_metadata=metadata)
             results = query.all()
             entities.update({e.name: e for e in results})
         return entities
@@ -513,7 +513,7 @@ class BIDSLayout(object):
         query = self.session.query(Tag).filter(Tag.file_path.in_(file_paths))
 
         if not metadata:
-            query = query.join(Entity).filter(Entity.is_metadata == False)
+            query = query.join(Entity).join(Tag).filter(Tag.is_metadata == False)
 
         tags = query.all()
 
@@ -680,7 +680,7 @@ class BIDSLayout(object):
             if return_type == 'id':
                 ent_iter = (x.get_entities(metadata=metadata) for x in results)
                 results = list({
-                    ents[target] for ents in ent_iter
+                    ents[target] for ents in ent_iter if target in ents
                 })
 
             elif return_type == 'dir':
@@ -879,7 +879,7 @@ class BIDSLayout(object):
                      .filter(BIDSFile.path == path))
 
             if not include_entities:
-                query = query.join(Entity).filter(Entity.is_metadata == True)
+                query = query.join(Entity).join(Tag).filter(Tag.is_metadata == True)
 
             results = query.all()
             if results:

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -313,7 +313,7 @@ class BIDSLayout(object):
 
         Note: This is only necessary if a database_path was not specified
         at initialization, and the user now wants to save the index.
-        If a database_path was specified originaquery = l.session.query(Entity)lly, there is no need to
+        If a database_path was specified originally, there is no need to
         re-save using this method.
 
         Parameters

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -513,7 +513,7 @@ class BIDSLayout(object):
         query = self.session.query(Tag).filter(Tag.file_path.in_(file_paths))
 
         if not metadata:
-            query = query.join(Entity).join(Tag).filter(Tag.is_metadata == False)
+            query = query.join(Entity).filter(Tag.is_metadata == False)
 
         tags = query.all()
 

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -675,12 +675,14 @@ class BIDSLayout(object):
                 raise TargetError('If return_type is "id" or "dir", a valid '
                                  'target entity must also be specified.')
 
-            results = [x for x in results if target in x.entities]
+            base_entities = self.get_entities(metadata=False)
+            metadata = False if target in base_entities else True
+            results = [x for x in results if target in x.get_entities(metadata=metadata)]
 
             if return_type == 'id':
                 results = list(set(
-                    [x.entities[target] for x in results 
-                     if type(x.entities[target]) is not dict]))
+                    [x.get_entities(metadata=metadata)[target] for x in results 
+                     if type(x.get_entities(metadata=metadata)[target]) is not dict]))
                 results = natural_sort(results)
 
             elif return_type == 'dir':

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -675,15 +675,13 @@ class BIDSLayout(object):
                 raise TargetError('If return_type is "id" or "dir", a valid '
                                  'target entity must also be specified.')
 
-            base_entities = self.get_entities(metadata=False)
-            metadata = False if target in base_entities else True
-            results = [x for x in results if target in x.get_entities(metadata=metadata)]
+            metadata = target not in self.get_entities(metadata=False)
 
             if return_type == 'id':
-                results = list(set(
-                    [x.get_entities(metadata=metadata)[target] for x in results 
-                     if type(x.get_entities(metadata=metadata)[target]) is not dict]))
-                results = natural_sort(results)
+                ent_iter = (x.get_entities(metadata=metadata) for x in results)
+                results = list({
+                    ents[target] for ents in ent_iter
+                })
 
             elif return_type == 'dir':
                 template = entities[target].directory


### PR DESCRIPTION
If return_type = 'id' ("shorthand queries") or 'dir' and "target" is a core BIDS entity (i.e. one that is derived from filenames, not from meta-data), then only look at results that are not from meta-data.

If you ask for `layout.get_runs()`, it will only look at values that came from files, not meta-data.
This should prevent collisions from similarly named meta-data values. 

However, if you ask for a meta-data target, then it will attempt to take a `set` across all values it finds:

```
In [5]: layout.get(target='SliceThickness', return_type='id')
Out[5]: [1, 2.5]
```

Related #694 