### PR TITLE
Patch 0.13.x maint branch 

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -678,8 +678,9 @@ class BIDSLayout(object):
             results = [x for x in results if target in x.entities]
 
             if return_type == 'id':
-                results = list(set([x.entities[target] for x in results]))
-                results = natural_sort(results)
+                results = list(set(
+                    [x.entities[target] for x in results 
+                     if type(x.entities[target]) is not dict]))
 
             elif return_type == 'dir':
                 template = entities[target].directory

--- a/bids/variables/io.py
+++ b/bids/variables/io.py
@@ -304,7 +304,7 @@ def _load_time_variables(layout, dataset=None, columns=None, scan_length=None,
             sub_ents = {k: v for k, v in entities.items()
                         if k in BASE_ENTITIES}
             confound_files = layout.get(suffix='regressors', scope=scope,
-                                        **sub_ents)
+                                        extension='.tsv', **sub_ents)
             for cf in confound_files:
                 _data = pd.read_csv(cf.path, sep='\t', na_values='n/a')
                 if columns is not None:


### PR DESCRIPTION
- Fixes issue #748 for 0.13.x series
- Explicitly only searches for `.tsv` files when loading event regressors