### PR TITLE
FIX: Take the intersection of variables and Model.X, ignoring missing variables (usually contrasts)

### DIFF
--- a/bids/modeling/statsmodels.py
+++ b/bids/modeling/statsmodels.py
@@ -641,8 +641,9 @@ class BIDSStatsModelsNodeOutput:
                 transformer = tm.TransformerManager(transformations['transformer'])
                 coll = transformer.transform(coll.clone(), transformations['instructions'])
 
-            # retain only variables listed in 'X', and skip level if none are left.
-            tm.Select(coll, var_names)
+            # Take the intersection of variables and Model.X (var_names), ignoring missing
+            # variables (usually contrasts)
+            coll.variables = {v: coll.variables[v] for v in var_names if v in coll.variables}
             if not coll.variables:
                 continue
 


### PR DESCRIPTION
The `Select` transform throws an error when a variable listed in `model.X` is not found in `collection.variables`.

This change retain collection variables directly if in `model.X`.

cc: @effigies 