### PR TITLE
MNT: Send codecov reports again

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -64,5 +64,5 @@ jobs:
         if: ${{ matrix.check != 'skiptests' }}
       - uses: codecov/codecov-action@v1
         with:
-          file: coverage.xml
+          file: cov.xml
         if: ${{ always() }}

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -96,5 +96,5 @@ jobs:
         if: ${{ matrix.check != 'skiptests' }}
       - uses: codecov/codecov-action@v1
         with:
-          file: coverage.xml
+          file: cov.xml
         if: ${{ always() }}


### PR DESCRIPTION
Looks like I screwed this up when moving to GitHub actions. Apologies.