### PR TITLE
Fix LGTM.com error: Explicit export is not defined

### DIFF
--- a/bids/modeling/__init__.py
+++ b/bids/modeling/__init__.py
@@ -7,7 +7,7 @@ __all__ = [
     'BIDSStatsModelsGraph',
     'BIDSStatsModelsNode',
     'BIDSStatsModelsNodeOutput',
-    'BIDSStatsModelsEdge'
+    'BIDSStatsModelsEdge',
     'auto_model',
     'TransformerManager'
 ]


### PR DESCRIPTION
The name '`BIDSStatsModelsEdgeauto_model`' is exported by `__all__` but is not defined.

https://lgtm.com/projects/g/bids-standard/pybids/snapshot/976c98e15da939181e2c95edbd04436ab96f8dfa/files/bids/modeling/__init__.py?sort=name&dir=ASC&mode=heatmap#x38a5146b1aca127f:1