### PR TITLE
Constrain formulaic version to 0.2.x .

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     scipy
     nibabel >=2.1
     pandas >=0.23
-    formulaic
+    formulaic >=0.2,<0.3
     sqlalchemy <1.4.0.dev0
     bids-validator
     num2words


### PR DESCRIPTION
Greetings!

I'm glad that [Formulaic](https://github.com/matthewwardrop/formulaic) is useful to you! As indicated in the project documentation, formulaic is not yet 100% API stable between major version bumps, and so I don't want to inadvertently break you. As such, please accept this patch to constrain the version of formulaic to the current series.

Best,
M