### PR TITLE
FIX: Catch UnicodeDecodeErrors along with JSONDecodeErrors for better reporting

### DIFF
--- a/bids/layout/index.py
+++ b/bids/layout/index.py
@@ -267,7 +267,7 @@ class BIDSLayoutIndexer:
             with open(path, 'r', encoding='utf-8') as handle:
                 try:
                     return json.load(handle)
-                except json.JSONDecodeError as e:
+                except (UnicodeDecodeError, json.JSONDecodeError) as e:
                     msg = f"Error occurred while trying to decode JSON from file {path}"
                     raise IOError(msg) from e
 

--- a/bids/layout/validation.py
+++ b/bids/layout/validation.py
@@ -79,10 +79,11 @@ def validate_root(root, validate):
         else:
             description = None
     else:
+        err = None
         try:
             with open(target, 'r', encoding='utf-8') as desc_fd:
                 description = json.load(desc_fd)
-        except json.JSONDecodeError:
+        except (UnicodeDecodeError, json.JSONDecodeError) as err:
             description = None
         if validate:
 
@@ -92,7 +93,7 @@ def validate_root(root, validate):
                     " There is likely a typo in your 'dataset_description.json'."
                     "\nExample contents of 'dataset_description.json': \n%s" %
                     json.dumps(EXAMPLE_BIDS_DESCRIPTION)
-                )
+                ) from err
 
             for k in MANDATORY_BIDS_FIELDS:
                 if k not in description:

--- a/bids/layout/validation.py
+++ b/bids/layout/validation.py
@@ -83,8 +83,9 @@ def validate_root(root, validate):
         try:
             with open(target, 'r', encoding='utf-8') as desc_fd:
                 description = json.load(desc_fd)
-        except (UnicodeDecodeError, json.JSONDecodeError) as err:
+        except (UnicodeDecodeError, json.JSONDecodeError) as e:
             description = None
+            err = e
         if validate:
 
             if description is None:


### PR DESCRIPTION
We report the failing file to the user if the JSON syntax is bad, but not if there's an invalid Unicode code point.