### PR TITLE
DOC: Link from sphinx documentation to notebook tutorials.

### DIFF
--- a/doc/analysis/index.rst
+++ b/doc/analysis/index.rst
@@ -61,3 +61,8 @@ JSON specification in ``model.json``.
     >>> dm = analysis[0].get_design_matrix(subject='01', run=1, task='taskA')
     >>> # Sample query: retrieve session-level contrast matrix
     >>> cm = analysis[1].get_contrasts(subject='01', session='retest')
+
+
+.. note::
+
+    For a more detailed set of examples, please refer to the `tutorial <https://github.com/bids-standard/pybids/blob/0.14.0/examples/statsmodels_tutorial.ipynb>`_

--- a/doc/layout/index.rst
+++ b/doc/layout/index.rst
@@ -69,3 +69,8 @@ We can also extract metadata from the json files associated with a scan file::
 
     >>> f = layout.get(task='nback', run=1, extension='nii.gz')[0].filename
     >>> layout.get_metadata(f)
+
+
+.. note::
+
+    For a more detailed set of examples, please refer to the `tutorial <https://github.com/bids-standard/pybids/blob/0.14.0/examples/pybids_tutorial.ipynb>`_


### PR DESCRIPTION
I noticed that the notebooks in the `examples` directory are not currently linked to the sphinx documentation. This adds a link to each of the notebooks. 

An alternative to this solution would be to convert the notebooks to inputs for sphinx gallery. I see this was raised in the past in https://github.com/bids-standard/pybids/issues/678. 

Another alternative would be to go full jupyter book / myst, which would probably require a bit more work. I could look into that if there is any enthusiasm about that.