### PR TITLE
FIX: Ensure layout description is always a dict, check for GeneratedBy

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -128,7 +128,7 @@ class BIDSLayout(object):
         root, description = validate_root(root, validate)
 
         self._root = root  # type: Path
-        self.description = description
+        self.description = description # type: dict
         self.absolute_paths = absolute_paths
         self.derivatives = {}
         self.sources = sources
@@ -235,7 +235,7 @@ class BIDSLayout(object):
 
         # We assume something is a BIDS-derivatives dataset if it either has a
         # defined pipeline name, or is applying the 'derivatives' rules.
-        pl_name = self.description.get("PipelineDescription", {}).get("Name")
+        pl_name = self.description.get("GeneratedBy", [{}])[0].get("Name")
         is_deriv = bool('derivatives' in self.config)
 
         return ((not is_deriv and 'raw' in scope) or

--- a/bids/layout/validation.py
+++ b/bids/layout/validation.py
@@ -79,14 +79,14 @@ def validate_root(root, validate):
                 json.dumps(EXAMPLE_BIDS_DESCRIPTION)
             )
         else:
-            description = None
+            description = {}
     else:
         err = None
         try:
             with open(target, 'r', encoding='utf-8') as desc_fd:
                 description = json.load(desc_fd)
         except (UnicodeDecodeError, json.JSONDecodeError) as e:
-            description = None
+            description = {}
             err = e
         if validate:
 


### PR DESCRIPTION
Closes #788. This avoids the problem of an error message by making sure the attribute has the appropriate type. Also cleaning up an old `PipelineDescription` reference that should be superseded by `GeneratedBy`.

This is a quick fix; I think we might want to think through this more carefully, since we claim we are depending on a metadata field other than `DatasetType` to determine if it's a derivative, but the check actually seems to be whether we loaded the `derivatives.json` config field, and we're using the pipeline name for other reasons.