### PR TITLE
ENH: Add new `Query` for optional entities

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -753,6 +753,9 @@ class BIDSLayout(object):
                 if val is None or val == Query.NONE:
                     join_method = query.outerjoin
                     val_clause = tag_alias._value.is_(None)
+                elif val == Query.ANY_OPTIONAL:
+                    join_method = query.outerjoin
+                    val_clause = sa.or_(tag_alias._value.is_(None), tag_alias._value.isnot(None))
                 elif val == Query.ANY:
                     val_clause = tag_alias._value.isnot(None)
                 elif regex:
@@ -1316,3 +1319,4 @@ class Query(enum.Enum):
     """Enums for use with BIDSLayout.get()."""
     NONE = 1 # Entity must not be present
     ANY = 2  # Entity must be defined, but with an arbitrary value
+    ANY_OPTIONAL = 3  # Entity may or may not be defined

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -753,9 +753,8 @@ class BIDSLayout(object):
                 if val is None or val == Query.NONE:
                     join_method = query.outerjoin
                     val_clause = tag_alias._value.is_(None)
-                elif val == Query.ANY_OPTIONAL:
-                    join_method = query.outerjoin
-                    val_clause = sa.or_(tag_alias._value.is_(None), tag_alias._value.isnot(None))
+                elif val == Query.OPTIONAL:
+                    continue
                 elif val == Query.ANY:
                     val_clause = tag_alias._value.isnot(None)
                 elif regex:
@@ -1318,5 +1317,5 @@ class BIDSLayout(object):
 class Query(enum.Enum):
     """Enums for use with BIDSLayout.get()."""
     NONE = 1 # Entity must not be present
-    ANY = 2  # Entity must be defined, but with an arbitrary value
-    ANY_OPTIONAL = 3  # Entity may or may not be defined
+    REQUIRED = ANY = 2  # Entity must be defined, but with an arbitrary value
+    OPTIONAL = 3  # Entity may or may not be defined

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -328,13 +328,13 @@ def test_get_val_enum_any_optional(layout_7t_trt, layout_ds005):
         "run": 1,
         "suffix": "bold",
     }
-    bold_files = layout_7t_trt.get(session=Query.ANY_OPTIONAL, **query)
+    bold_files = layout_7t_trt.get(session=Query.OPTIONAL, **query)
     assert len(bold_files) == 3
 
     # layout without sessions
-    bold_files = layout_ds005.get(session=Query.ANY, **query)
+    bold_files = layout_ds005.get(session=Query.REQUIRED, **query)
     assert not bold_files
-    bold_files = layout_ds005.get(session=Query.ANY_OPTIONAL, **query)
+    bold_files = layout_ds005.get(session=Query.OPTIONAL, **query)
     assert len(bold_files) == 1
 
 

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -321,6 +321,23 @@ def test_get_val_enum_any(layout_7t_trt):
     assert len(bold_files) == 2
 
 
+def test_get_val_enum_any_optional(layout_7t_trt, layout_ds005):
+    # layout with sessions
+    query = {
+        "subject": "01",
+        "run": 1,
+        "suffix": "bold",
+    }
+    bold_files = layout_7t_trt.get(session=Query.ANY_OPTIONAL, **query)
+    assert len(bold_files) == 3
+
+    # layout without sessions
+    bold_files = layout_ds005.get(session=Query.ANY, **query)
+    assert not bold_files
+    bold_files = layout_ds005.get(session=Query.ANY_OPTIONAL, **query)
+    assert len(bold_files) == 1
+
+
 def test_get_return_sorted(layout_7t_trt):
     bids_files = layout_7t_trt.get(target='subject')
     paths = [r.path for r in bids_files]


### PR DESCRIPTION
Mimics `Query.ANY` but allows matching when entity is not present altogether.
See https://github.com/bids-standard/pybids/issues/808