### PR TITLE
MNT: Avoid jinja2 v3 until nbconvert handles breakages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools >= 30.3.0", "wheel"]
+requires = ["setuptools >= 30.3.0, != 61.0.0", "wheel"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,7 @@ ci_tests =
     pytest-xdist
 tutorial =
     nbconvert
+    jinja2 <3  # Required until nbconvert handles all deprecations/removals
     jupyter_client
     ipykernel
 dev =

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,7 @@ ci_tests =
 tutorial =
     nbconvert
     jinja2 <3  # Required until nbconvert handles all deprecations/removals
+    markupsafe <2.1  # Required until we can upgrade jinja2
     jupyter_client
     ipykernel
 dev =

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import versioneer
 # Give setuptools a hint to complain if it's too old a version
 # 30.3.0 allows us to put most metadata in setup.cfg
 # Should match pyproject.toml
-SETUP_REQUIRES = ['setuptools >= 30.3.0']
+SETUP_REQUIRES = ['setuptools >= 30.3.0, != 61.0.0']
 # This enables setuptools to install wheel on-the-fly
 SETUP_REQUIRES += ['wheel'] if 'bdist_wheel' in sys.argv else []
 

--- a/tools/ci/env.sh
+++ b/tools/ci/env.sh
@@ -1,4 +1,4 @@
-SETUP_REQUIRES="pip setuptools>=30.3.0 wheel"
+SETUP_REQUIRES="pip setuptools>=30.3.0,!=61.0.0 wheel"
 
 # Numpy and scipy upload nightly/weekly/intermittent wheels
 NIGHTLY_WHEELS="https://pypi.anaconda.org/scipy-wheels-nightly/simple"


### PR DESCRIPTION
Jinja2 is breaking everything for everybody. We don't directly depend on it, but nbconvert doesn't have fixes out yet.

Also, it seems setuptools stopped packaging data in 61.0.0.

xref https://github.com/jupyter/nbconvert/pull/1737 https://github.com/pypa/setuptools/issues/3196