### PR TITLE
REL: 0.14.1

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -23,6 +23,7 @@ Matteo Visconti di Oleggio Castello <matteo.visconti.gr@dartmouth.edu>
 Mathias Goncalves <mathiasg@stanford.edu>
 Mathias Goncalves <mathiasg@stanford.edu> Mathias Goncalves <goncalves.mathias@gmail.com>
 Michael Philipp Notter <michaelnotter@hotmail.com>
+Nick Guenther <nick.guenther@polymtl.ca>
 Oscar Esteban <code@oscaresteban.es>
 Steven Tilley II <stilley@hollandbloorview.ca>
 Steven Tilley II <stilley@hollandbloorview.ca> <steve@steventilley.com>

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -234,6 +234,10 @@
       "orcid": "0000-0003-3028-9864"
     },
     {
+      "name": "Staph, Jason A.",
+      "orcid": "0000-0002-5226-3350"
+    },
+    {
       "affiliation": "NIMH IRP",
       "name": "Lee, John A.",
       "orcid": "0000-0001-5884-4247"
@@ -250,6 +254,10 @@
       "affiliation": "The Laboratory for Investigative Neurophysiology (The LINE), Department of Radiology and Department of Clinical Neurosciences, Lausanne, Switzerland; Center for Biomedical Imaging (CIBM), Lausanne, Switzerland",
       "name": "Notter, Michael Philipp",
       "orcid": "0000-0002-5866-047X"
+    },
+    {
+      "affiliation": "Polytechnique Montr\u00e9al",
+      "name": "Guenther, Nick"
     },
     {
       "affiliation": "Sainte-Anne Hospital Center, Universit\u00e9 Paris Descartes",

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,19 @@
 Changelog
 =========
 
+Version 0.14.1 (March 29, 2022)
+-------------------------------
+Bug-fix release in the 0.14.x series.
+
+* RF/FIX: Decompose filter construction for special queries and lists (#826)
+
+Includes the following back-ports from 0.15.0:
+
+* FIX: Clarify exception message (#806)
+* FIX: Catch UnicodeDecodeErrors along with JSONDecodeErrors for better reporting (#796)
+* FIX: Accept paths/strings for layout configuration files (#799)
+* ENH: Add __main__ to allow ``python -m bids`` to run CLI (#794)
+
 Version 0.14.0 (November 09, 2021)
 ----------------------------------
 

--- a/tools/prep_zenodo.py
+++ b/tools/prep_zenodo.py
@@ -13,7 +13,7 @@ def decommify(name):
 # XXX We should add a shortlog since the most recent tag and explicitly note
 # that a blacklisted user has contributed again recently, and verify they still
 # do not want to be cited.
-blacklist = {'Cecile Madjar'}
+blacklist = {'Cecile Madjar', 'Matthew Wardrop', 'Peter Van Dyken'}
 
 # List of repositories whose commits should be counted as contributions
 codependents = [('https://github.com/grabbles/grabbit.git', '0.2.6')]


### PR DESCRIPTION
Need #826 without #819, so we need a 0.14.1 release.

Backported some easily-backportable PRs as well.