### PR TITLE
TEST: Add bids-examples submodule and bids_examples pytest fixture

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "bids-examples"]
+	path = bids-examples
+	url = https://github.com/bids-standard/bids-examples.git

--- a/bids/conftest.py
+++ b/bids/conftest.py
@@ -13,8 +13,10 @@ e.g.
 ...     assert bids.config.get_option("extension_initial_dot") == extension_initial_dot
 """
 
-
+import os
+from pathlib import Path
 from unittest.mock import patch
+
 import pytest
 
 @pytest.fixture
@@ -34,3 +36,17 @@ def mock_config(config_paths, extension_initial_dot):
         bids.config._settings['config_paths'] = config_paths
         bids.config._settings['extension_initial_dot'] = extension_initial_dot
         yield
+
+@pytest.fixture(scope='session')
+def bids_examples():
+    examples_dir = Path(os.getenv(
+        "BIDS_EXAMPLES",
+        Path(__file__).absolute().parent.parent / "bids-examples"
+    ))
+
+    if not Path.is_dir(examples_dir / "ds001"):
+        pytest.skip(
+            f"BIDS examples missing from {examples_dir}. "
+            "Override default location with BIDS_EXAMPLES environment variable."
+        )
+    return examples_dir


### PR DESCRIPTION
This makes all BIDS examples available to pybids for testing through the `bids_examples` fixture. To enable it, either clone the repository recursively, init/update the submodule, or point to a copy of bids-examples with the `BIDS_EXAMPLES` environment variable.

To use it, write something like:

```Python
def test_ds005(bids_examples):
    ds005 = bids_examples / "ds005"
    layout = BIDSLayout(ds005)
    ...
```

We may want to consider a test that fails when the submodule becomes out of sync with `bids-examples:main` (or `:master`... not sure what we're using over there).

cc @Remi-Gau 