### PR TITLE
statsmodels: rename contrasts if they cannot be uniquely identified downstream

### DIFF
--- a/bids/modeling/statsmodels.py
+++ b/bids/modeling/statsmodels.py
@@ -587,11 +587,10 @@ class BIDSStatsModelsNodeOutput:
 
         var_names = list(self.node.model['x'])
 
-        # Handle the special 1 construct. If it's present, we add a
-        # column of 1's to the design matrix called "intercept" 
+        # Handle the special 1 construct.
+        # Add column of 1's to the design matrix called "intercept" 
         if 1 in var_names:
-            var_names.remove(1)
-            var_names.append('intercept')
+            var_names = ['intercept' if i == 1 else i for i in var_names]
             if 'intercept' not in df.columns:
                 df.insert(0, 'intercept', 1)
 
@@ -685,7 +684,7 @@ class BIDSStatsModelsNodeOutput:
         Parameters
         ----------
         unique_in_contrast : string
-            Name of unique incoming contrast inputs (if there is only 1)
+            Name of unique incoming contrast inputs (i.e. if there is only 1)
         """
         in_contrasts = self.node.contrasts.copy()
         col_names = set(self.X.columns)
@@ -708,16 +707,14 @@ class BIDSStatsModelsNodeOutput:
                     }
                 )
 
-        # Process all contrasts. 
-        # Dummy contrasts first, they are over-ridden if a contrast with the same
-        # name is specified
+        # Process all contrasts, starting with dummy contrasts 
+        # Dummy contrasts are replaced if a contrast is defined with same name
         contrasts = {}
         for con in in_contrasts:
             condition_list = list(con["condition_list"])
 
-            # Rename special 1 construct to intercept
-            if 1 in condition_list:
-                condition_list[condition_list.index(1)] = 'intercept'
+            # Rename special 1 construct
+            condition_list = ['intercept' if i == 1 else i for i in condition_list]
 
             name = con["name"]
             

--- a/bids/modeling/statsmodels.py
+++ b/bids/modeling/statsmodels.py
@@ -598,7 +598,7 @@ class BIDSStatsModelsNodeOutput:
                 var_names.append('intercept')
 
         # If a single incoming contrast
-        if ('contrast' in df.columns or df['contrast'].nunique() == 1):
+        if ('contrast' in df.columns and df['contrast'].nunique() == 1):
             unique_in_contrast = df['contrast'].unique()[0]
         else:
             unique_in_contrast = None

--- a/bids/modeling/statsmodels.py
+++ b/bids/modeling/statsmodels.py
@@ -4,6 +4,7 @@ import json
 from collections import namedtuple, OrderedDict, Counter, defaultdict
 import itertools
 from functools import reduce
+from multiprocessing.sharedctypes import Value
 import re
 import fnmatch
 
@@ -263,11 +264,11 @@ class BIDSStatsModelsNode:
         overridden if one is passed when run() is called on a node.
     """
 
-    def __init__(self, level, name, transformations=None, model=None,
-                 contrasts=None, dummy_contrasts=False, group_by=None):
+    def __init__(self, level, name, model, group_by, transformations=None,
+                 contrasts=None, dummy_contrasts=False):
         self.level = level.lower()
         self.name = name
-        self.model = model or {}
+        self.model = model
         if transformations is None:
             transformations = {"transformer": "pybids-transforms-v1",
                                "instructions": []}
@@ -279,13 +280,7 @@ class BIDSStatsModelsNode:
         self.children = []
         self.parents = []
         if group_by is None:
-            group_by = []
-            # Loop over contrasts after first level
-            if self.level != "run":
-                group_by.append("contrast")
-            # Loop over node level of this node
-            if self.level != "dataset":
-                group_by.append(self.level)
+            raise ValueError(f"group_by is not defined for Node: {name}")
         self.group_by = group_by
 
         # Check for intercept only run level model and throw an error

--- a/bids/modeling/statsmodels.py
+++ b/bids/modeling/statsmodels.py
@@ -598,7 +598,7 @@ class BIDSStatsModelsNodeOutput:
                 var_names.append('intercept')
 
         # If a single incoming contrast
-        if ('contrast' not in df.columns or df['contrast'].nunique() == 1):
+        if ('contrast' in df.columns or df['contrast'].nunique() == 1):
             unique_in_contrast = df['contrast'].unique()[0]
         else:
             unique_in_contrast = None

--- a/bids/modeling/statsmodels.py
+++ b/bids/modeling/statsmodels.py
@@ -713,7 +713,7 @@ class BIDSStatsModelsNodeOutput:
         # Dummy contrasts first, they are over-ridden if a contrast with the same
         # name is specified
         contrasts = {}
-        for con in self.node.contrasts:
+        for con in in_contrasts:
             condition_list = list(con["condition_list"])
 
             # Rename special 1 construct to intercept

--- a/bids/modeling/statsmodels.py
+++ b/bids/modeling/statsmodels.py
@@ -704,6 +704,7 @@ class BIDSStatsModelsNodeOutput:
                 in_contrasts.insert(0, 
                     {
                         'name': col_name,
+                        'conditionlist': [col_name],
                         'weights': [1],
                         'test': dummies.get('test')
                     }
@@ -714,7 +715,7 @@ class BIDSStatsModelsNodeOutput:
         # name is specified
         contrasts = {}
         for con in in_contrasts:
-            condition_list = list(con["condition_list"])
+            condition_list = list(con["conditionlist"])
 
             # Rename special 1 construct to intercept
             if 1 in condition_list:

--- a/bids/modeling/statsmodels.py
+++ b/bids/modeling/statsmodels.py
@@ -591,11 +591,9 @@ class BIDSStatsModelsNodeOutput:
         # column of 1's to the design matrix called "intercept" 
         if 1 in var_names:
             var_names.remove(1)
-
+            var_names.append('intercept')
             if 'intercept' not in df.columns:
                 df.insert(0, 'intercept', 1)
-            else:
-                var_names.append('intercept')
 
         # If a single incoming contrast
         if ('contrast' in df.columns and df['contrast'].nunique() == 1):
@@ -696,7 +694,7 @@ class BIDSStatsModelsNodeOutput:
         dummies = self.node.dummy_contrasts
         if dummies:
             if 'conditionlist' in dummies:
-                conditions = set(dummies['conditionlist'])
+                conditions = set(dummies['condition_list'])
             else:
                 conditions = col_names
 
@@ -704,7 +702,7 @@ class BIDSStatsModelsNodeOutput:
                 in_contrasts.insert(0, 
                     {
                         'name': col_name,
-                        'conditionlist': [col_name],
+                        'condition_list': [col_name],
                         'weights': [1],
                         'test': dummies.get('test')
                     }
@@ -715,7 +713,7 @@ class BIDSStatsModelsNodeOutput:
         # name is specified
         contrasts = {}
         for con in in_contrasts:
-            condition_list = list(con["conditionlist"])
+            condition_list = list(con["condition_list"])
 
             # Rename special 1 construct to intercept
             if 1 in condition_list:

--- a/bids/modeling/tests/test_statsmodels.py
+++ b/bids/modeling/tests/test_statsmodels.py
@@ -140,7 +140,7 @@ def test_entire_graph_smoketest(graph):
     assert model_spec.X.shape == (2, 2)
     assert model_spec.Z is None
     assert len(model_spec.terms) == 2
-    assert not set(model_spec.terms.keys()) - {"RT", "gain", "RT:gain", "sex"}
+    assert not set(model_spec.terms.keys()) - {"intercept", "sex"}
 
     # BY-GROUP NODE
     outputs = graph["by-group"].run(inputs, group_by=['contrast'])
@@ -153,7 +153,7 @@ def test_entire_graph_smoketest(graph):
     assert model_spec.__class__.__name__ == "GLMMSpec"
     assert model_spec.X.shape == (2, 1)
     assert model_spec.Z is None
-    assert not set(model_spec.terms.keys()) - {"RT", "gain", "RT:gain"}
+    assert not set(model_spec.terms.keys()) - {"intercept"}
 
 
 def test_expand_wildcards():

--- a/bids/modeling/tests/test_statsmodels.py
+++ b/bids/modeling/tests/test_statsmodels.py
@@ -113,10 +113,22 @@ def test_entire_graph_smoketest(graph):
     cis = list(chain(*[op.contrasts for op in outputs]))
     assert len(cis) == 18
     outputs = graph["participant"].run(cis, group_by=['subject', 'contrast'])
-    # 2 subjects x 3 contrasts
+    # 2 subjects x 3 contrasts)
     assert len(outputs) == 6
+    # * 2 participant level contrasts = 12
     cis = list(chain(*[op.contrasts for op in outputs]))
-    assert len(cis) == 6
+    assert len(cis) == 12
+
+    # Test output names for single subject
+    out_contrasts = [
+        c.entities['contrast'] for c in cis if c.entities['subject'] == '01'
+        ]
+
+    expected_outs = [
+        'gain', 'gain_neg', 'RT', 'RT_neg', 'RT:gain', 'RT:gain_neg'
+    ]
+
+    assert set(out_contrasts) == set(expected_outs)
 
     # Construct new ContrastInfo objects with name updated to reflect last
     # contrast. This would normally be done by the handling tool (e.g., fitlins)

--- a/bids/tests/data/ds005/models/ds-005_type-test_model.json
+++ b/bids/tests/data/ds005/models/ds-005_type-test_model.json
@@ -53,6 +53,12 @@
                     "ConditionList": [1],
                     "Weights": [1],
                     "Test": "FEMA"
+                },
+                {
+                    "Name": "neg",
+                    "ConditionList": [1],
+                    "Weights": [-1],
+                    "Test": "FEMA"
                 }
             ]
         },
@@ -60,7 +66,8 @@
             "Name": "by-group",
             "Level": "Dataset",
             "GroupBy": [
-                "sex"
+                "sex",
+                "contrast"
             ],
             "Model": {
                 "X": [
@@ -75,7 +82,7 @@
         {
             "Name": "group-diff",
             "Level": "Dataset",
-            "GroupBy": [],
+            "GroupBy": ["contrast"],
             "Model": {
                 "X": [
                     1,

--- a/bids/tests/data/ds005/models/ds-005_type-test_model.json
+++ b/bids/tests/data/ds005/models/ds-005_type-test_model.json
@@ -25,10 +25,6 @@
                     "Name": "Rename",
                     "Input": "trial_type.parametric gain",
                     "Output": "gain"
-                },
-                {
-                    "Name": "Scale",
-                    "Input": "RT"
                 }
             ],
             "DummyContrasts": {


### PR DESCRIPTION
Addresses: https://github.com/bids-standard/stats-models/issues/40

- Implements renaming these contrasts to prepend the incoming contrast name
- Refactored `DummyContrasts` to simply create Contrasts prior to processing Contrasts. That way, they are processed like any other contrast, and the logic for dealing w/ `1` and other special contrasts is not repeated. 

This might be more controversial but previously the `1` construct would add an intercept named either "intercept" or (in the case of only having one incoming contrast to that Node) the contrast name. Instead, I propose we simply rename the _Contrasts_ if it references the special `1` construct, but always call the intercept "intercept" in the design matrix itself.

I don't feel super strongly about this last bit, but it complicated the logic. Now simply we need to rename the `Contrast` if it references `1`, and add an intercept called `intercept` if needed to X.