### PR TITLE
MNT: Codespell errors

### DIFF
--- a/.github/codespell_exclude_lines.txt
+++ b/.github/codespell_exclude_lines.txt
@@ -1,0 +1,8 @@
+        "/RADME",  # wrong filename
+        "/CANGES",  # wrong filename
+        "/dataset_descrption.json",  # wrong filename
+        "/dataset_description.jon",  # wrong extension
+        "/participants.sv",  # wrong extension
+        "/participnts.tsv",  # wrong filename
+        "/particpants.json"  # wrong filename
+        "/participants.son"  # wrong extension

--- a/bids/layout/tests/test_validation.py
+++ b/bids/layout/tests/test_validation.py
@@ -33,13 +33,13 @@ def test_is_top_level_true(testvalidator):
 # checks is_top_level() function false cases
 def test_is_top_level_false(testvalidator):
     target_list = [
-        "/RADME",  # wrong the the filename
-        "/CANGES",  # wrong the the filename
-        "/dataset_descrption.json",  # wrong the the filename
+        "/RADME",  # wrong filename
+        "/CANGES",  # wrong filename
+        "/dataset_descrption.json",  # wrong filename
         "/dataset_description.jon",  # wrong extension
         "/participants.sv",  # wrong extension
-        "/participnts.tsv",  # wrong the the filename
-        "/particpants.json"  # wrong the the filename
+        "/participnts.tsv",  # wrong filename
+        "/particpants.json"  # wrong filename
         "/participants.son"  # wrong extension
     ]
 

--- a/bids/layout/tests/test_validation.py
+++ b/bids/layout/tests/test_validation.py
@@ -216,9 +216,9 @@ def test_is_subject_false(testvalidator):
 
 
 # def test_is_anat_false(testvalidator):
-#     target_list = ["/sub-01/anat/sub-1_T1w.json",  # subject incosistency
+#     target_list = ["/sub-01/anat/sub-1_T1w.json",  # subject inconsistency
 #                    "/sub-01/anat/sub-01_dwi.nii.gz",  # wrong modality suffix
-#                    "/sub-01/anat/sub-02_rec-CSD_T1w.json",  # subject incosistency
+#                    "/sub-01/anat/sub-02_rec-CSD_T1w.json",  # subject inconsistency
 #                    "/sub-01/anat/sub-01_rec-CS-D_T1w.nii.gz",  # rec label wrong
 #                    "/sub-01/anat/sub-01_acq-23_T1W.json",  # modality suffix wrong
 #                    "/sub-01/dwi/sub-01_acq-23_dwi.nii.gz",  # wrong data type

--- a/bids/modeling/tests/test_transformations.py
+++ b/bids/modeling/tests/test_transformations.py
@@ -76,7 +76,7 @@ def test_convolve(collection):
         collection.variables['rt_dense_derivative'].values.shape[0] == \
         rt.get_duration() * collection.sampling_rate
 
-    # Test adapative oversampling computation
+    # Test adaptive oversampling computation
     # Events are 3s duration events every 4s, so resolution demanded by the data is 1Hz
     # To resolve 1Hz frequencies, we must sample at >=2Hz
     args = (mock.ANY, 'spm', mock.ANY)

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,3 +82,4 @@ parentdir_prefix =
 [codespell]
 skip = ./.git,external,versioneer.py,_version.py
 ignore-words = .github/codespell_ignore_words.txt
+exclude-file = .github/codespell_exclude_lines.txt


### PR DESCRIPTION
Looks like somebody updated their dictionary. They're now catching some intentional misspellings, too, so add an exclude file.