### PR TITLE
Fix filtering of DM columns

### DIFF
--- a/bids/modeling/statsmodels.py
+++ b/bids/modeling/statsmodels.py
@@ -586,11 +586,17 @@ class BIDSStatsModelsNodeOutput:
         df = reduce(pd.DataFrame.merge, dfs)
 
         var_names = list(self.node.model['x'])
-    
-        # If a single incoming contrast, set to intercept
+
+        # If dummy coded condition columns needed, generate and concat
+        if inputs:
+            dummy_df = pd.get_dummies(df['contrast'])
+            dummies_needed = set(var_names).intersection(dummy_df)
+            if dummies_needed:
+                df = pd.concat([df, dummy_df[dummies_needed]], axis=1)
+
+        # If a single incoming contrast, keep track of name
         if 'contrast' in df.columns and df['contrast'].nunique() == 1:
             unique_in_contrast = df['contrast'].unique()[0]
-            df.rename(columns={unique_in_contrast: 'intercept'}, inplace=True)
         else:
             unique_in_contrast = None
 
@@ -668,15 +674,9 @@ class BIDSStatsModelsNodeOutput:
 
     def _inputs_to_df(self, inputs):
         # Convert the inputs to a DataFrame and add to list. Each row is
-        # an input; each column is either an entity or a contrast name from
-        # the previous level.
-        if inputs:
-            rows = [{**con.entities, 'contrast': con.name} for con in inputs]
-            input_df = pd.DataFrame.from_records(rows)
-            for i, con in enumerate(inputs):
-                if con.name not in input_df.columns:
-                    input_df.loc[:, con.name] = 0
-                input_df.loc[input_df.index[i], con.name] = 1
+        # an input; each column is an entity
+        rows = [{**con.entities, 'contrast': con.name} for con in inputs]
+        input_df = pd.DataFrame.from_records(rows)
         return input_df
 
     def _build_contrasts(self, unique_in_contrast=None):

--- a/bids/modeling/tests/test_statsmodels.py
+++ b/bids/modeling/tests/test_statsmodels.py
@@ -167,6 +167,20 @@ def test_entire_graph_smoketest(graph):
     assert model_spec.Z is None
     assert not set(model_spec.terms.keys()) - {"intercept"}
 
+    # explicit-contrast NODE
+    outputs = graph["explicit-contrast"].run(inputs)
+    # 1 group x 1 contrast
+    assert len(outputs) == 1
+    assert len(outputs[0].contrasts) == 1
+    assert outputs[0].X['gain'].sum() == 2
+    model_spec = outputs[0].model_spec
+    assert model_spec.__class__.__name__ == "GLMMSpec"
+    assert model_spec.X.shape == (6, 1)
+    assert not set(model_spec.terms.keys()) - {"gain"}
+
+    contrast = outputs[0].contrasts[0]
+    assert contrast.name == 'gain'
+    
 
 def test_expand_wildcards():
     # No wildcards == no modification

--- a/bids/modeling/tests/test_statsmodels.py
+++ b/bids/modeling/tests/test_statsmodels.py
@@ -107,12 +107,12 @@ def test_entire_graph_smoketest(graph):
     # Note that there are only 2 subjects in the graph.
     # Note also that there is only one session (with no session label), which
     # should have no effect as a grouping variable
-    outputs = graph["run"].run(group_by=['subject', 'session', 'run'])
+    outputs = graph["run"].run()
     # 2 subjects x 3 runs
     assert len(outputs) == 6
     cis = list(chain(*[op.contrasts for op in outputs]))
     assert len(cis) == 18
-    outputs = graph["participant"].run(cis, group_by=['subject', 'contrast'])
+    outputs = graph["participant"].run(cis)
     # 2 subjects x 3 contrasts)
     assert len(outputs) == 6
     # * 2 participant level contrasts = 12
@@ -141,7 +141,7 @@ def test_entire_graph_smoketest(graph):
         inputs.append(ContrastInfo(**fields))
 
     # GROUP DIFFERENCE NODE
-    outputs = graph["group-diff"].run(inputs, group_by=['contrast'])
+    outputs = graph["group-diff"].run(inputs)
     # 3 contrasts
     assert len(outputs) == 3
     cis = list(chain(*[op.contrasts for op in outputs]))
@@ -155,7 +155,7 @@ def test_entire_graph_smoketest(graph):
     assert not set(model_spec.terms.keys()) - {"intercept", "sex"}
 
     # BY-GROUP NODE
-    outputs = graph["by-group"].run(inputs, group_by=['contrast'])
+    outputs = graph["by-group"].run(inputs)
     # 3 contrasts
     assert len(outputs) == 3
     cis = list(chain(*[op.contrasts for op in outputs]))

--- a/bids/tests/data/ds005/models/ds-005_type-test_model.json
+++ b/bids/tests/data/ds005/models/ds-005_type-test_model.json
@@ -59,10 +59,9 @@
             ]
         },
         {
-            "Name": "by-group",
+            "Name": "by-contrast",
             "Level": "Dataset",
             "GroupBy": [
-                "sex",
                 "contrast"
             ],
             "Model": {

--- a/bids/tests/data/ds005/models/ds-005_type-test_model.json
+++ b/bids/tests/data/ds005/models/ds-005_type-test_model.json
@@ -59,7 +59,7 @@
             ]
         },
         {
-            "Name": "by-contrast",
+            "Name": "by-group",
             "Level": "Dataset",
             "GroupBy": [
                 "contrast"

--- a/bids/tests/data/ds005/models/ds-005_type-test_model.json
+++ b/bids/tests/data/ds005/models/ds-005_type-test_model.json
@@ -87,6 +87,13 @@
             "DummyContrasts": {
                 "Test": "t"
             }
+        },
+        {
+            "Name": "explicit-contrast",
+            "Level": "Dataset",
+            "GroupBy": [],
+            "Model": {"X": ["gain"], "Type": "glm"},
+            "DummyContrasts": {"Test": "t"}
         }
     ],
     "Edges": [
@@ -101,6 +108,11 @@
         {
             "Source": "participant",
             "Destination": "group-diff"
+        },
+        {
+            "Source": "participant",
+            "Destination": "explicit-contrast",
+            "Filter": {"contrast": ["gain"]}
         }
     ]
 }


### PR DESCRIPTION
Picking up where I left off in #886

First off, I'm changing the tests such that the smoketest runs on the defined model. Previously the `group_by` for each level was set manually rather than respecting what was the `.json` model. 

Second, removing `group_by` contrast, indeed does produce three dummy coded variables (as expected):

![Screenshot from 2022-09-06 19-00-23](https://user-images.githubusercontent.com/2774448/188760367-0d1bc495-a63d-4b6b-bf49-f8b093813b55.png)

However, I don't see where these extra columns would get filtered in the current code. Thus I think the real solution here is to:
- Inject a `intercept` column if defined in X
- Keep track that if there is only a single `contrast`, this `intercept` is effectively that contrast's mean (for convenience, we name the contrast that, instead of `intercept`)
- Filter the DM based on what's in `X`, not simply assuming all other variables are "meta-data"