### PR TITLE
Accept variable collections at any level

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -10,10 +10,7 @@ on:
     branches:
       - master
       - maint/*
-  pull_request:
-    branches:
-      - master
-      - maint/*
+  pull_request: {}
   schedule:
     # 8am EST / 9am EDT M-F
     - cron: '0 13 * * 1,2,3,4,5'

--- a/bids/modeling/statsmodels.py
+++ b/bids/modeling/statsmodels.py
@@ -297,7 +297,8 @@ class BIDSStatsModelsNode:
     def __repr__(self):
         return f"<{self.__class__.__name__}[{self.level}] {self.name}>"
 
-    def _build_groups(self, objects, group_by):
+    @staticmethod
+    def _build_groups(objects, group_by):
         """Group list of objects into bins defined by specified entities.
 
         Parameters
@@ -344,13 +345,10 @@ class BIDSStatsModelsNode:
 
         # Separate BIDSVariableCollections
         collections = [obj.to_df() for obj in objects if type(obj) == BIDSVariableCollection]
-        if self.level in ['subject', 'dataset'] and collections:
+        if collections:
             metadata_vars = reduce(pd.DataFrame.merge, collections)
-            on_var = {
-                'subject': 'session',
-                'dataset': 'subject'
-            }
-            df = df.merge(metadata_vars, how='left', on=on_var[self.level])
+            on_vars = list({'subject', 'session', 'run'} & set(metadata_vars.columns))
+            df = df.merge(metadata_vars, how='left', on=on_vars)
 
         # Single-run tasks and single-session subjects may not have entities
         dummy_groups = {"run", "session"} - set(df.columns)

--- a/bids/tests/data/ds005/sub-01/sub-01_scans.tsv
+++ b/bids/tests/data/ds005/sub-01/sub-01_scans.tsv
@@ -1,0 +1,6 @@
+filename	acq_time	meanRT
+anat/sub-01_T1w.nii.gz	1880-01-10T05:17:54	n/a
+dwi/sub-01_dwi.nii.gz	1880-01-10T05:18:54	n/a
+func/sub-01_task-mixedgamblestask_run-01_bold.nii.gz	1880-01-10T05:22:54	0.4
+func/sub-01_task-mixedgamblestask_run-02_bold.nii.gz	1880-01-10T05:37:54	0.5
+func/sub-01_task-mixedgamblestask_run-03_bold.nii.gz	1880-01-10T05:52:54	0.3

--- a/bids/tests/data/ds005/sub-02/sub-02_scans.tsv
+++ b/bids/tests/data/ds005/sub-02/sub-02_scans.tsv
@@ -1,0 +1,6 @@
+filename	acq_time	meanRT
+anat/sub-02_T1w.nii.gz	1880-01-10T05:17:54	n/a
+dwi/sub-02_dwi.nii.gz	1880-01-10T05:18:54	n/a
+func/sub-02_task-mixedgamblestask_run-01_bold.nii.gz	1880-01-10T05:22:54	0.5
+func/sub-02_task-mixedgamblestask_run-02_bold.nii.gz	1880-01-10T05:37:54	0.3
+func/sub-02_task-mixedgamblestask_run-03_bold.nii.gz	1880-01-10T05:52:54	0.4

--- a/bids/variables/io.py
+++ b/bids/variables/io.py
@@ -483,11 +483,12 @@ def _load_tsv_variables(layout, suffix, dataset=None, columns=None,
         # Filter rows on all selectors
         comm_cols = list(set(_data.columns) & set(selectors.keys()))
         for col in comm_cols:
-            ent_patts = [make_patt(x, regex_search=layout.regex_search)
-                            for x in listify(selectors.get(col))]
-            patt = '|'.join(ent_patts)
-
-            _data = _data[_data[col].str.contains(patt)]
+            vals = listify(selectors.get(col))
+            if layout.regex_search and any(isinstance(val, str) for val in vals):
+                ent_patts = '|'.join(make_patt(x, regex_search=True) for x in vals)
+                _data = _data[_data[col].str.contains(patt)]
+            else:
+                _data = _data[_data[col].isin(vals)]
 
         level = {'scans': 'session', 'sessions': 'subject',
                  'participants': 'dataset'}[suffix]

--- a/bids/variables/io.py
+++ b/bids/variables/io.py
@@ -71,7 +71,7 @@ def load_variables(layout, types=None, levels=None, skip_empty=True,
             lev_map = {
                 'run': ['events', 'physio', 'stim', 'regressors'],
                 'session': ['scans'],
-                'subject': ['sessions'],
+                'subject': ['sessions', 'scans'],
                 'dataset': ['participants']
             }
             [types.extend(lev_map[l.lower()]) for l in listify(levels)]

--- a/bids/variables/tests/test_entities.py
+++ b/bids/variables/tests/test_entities.py
@@ -54,8 +54,10 @@ def test_get_or_create_node(layout1):
 
 def test_get_nodes(layout1):
     index = load_variables(layout1, scan_length=480)
+    # scans.tsv
     nodes = index.get_nodes('session')
-    assert len(nodes) == 0
+    assert len(nodes) == 2
+    # participants.tsv
     nodes = index.get_nodes('dataset')
     assert len(nodes) == 1
     assert all([isinstance(n, Node) for n in nodes])

--- a/bids/variables/tests/test_io.py
+++ b/bids/variables/tests/test_io.py
@@ -56,7 +56,7 @@ def test_load_participants(layout1):
     assert age.index.shape == (16, 2)
     assert age.values.shape == (16,)
 
-    index = load_variables(layout1, types='participants', subject=['^1.*'])
+    index = load_variables(layout1, types='participants', subject=['^1.*'], regex_search=True)
     age = index.get_nodes(level='dataset')[0].variables['age']
     assert age.index.shape == (7, 2)
     assert age.values.shape == (7,)


### PR DESCRIPTION
Proposal for #894.

I added some `scans.tsv` files to ensure that we don't break things when they aren't filtered by level. I also added `scans` to the valid files to load at the subject level, as they can exist there for single-session datasets (like our test dataset). This led to fixing a small bug when filtering scans.tsv variables by run. (We were converting to strings and doing a pattern match. This fails when run is missing, e.g., from T1w files, so the column becomes float, which can't be converted.)