### PR TITLE
Transformations: sync_kwargs, for non-list arguments, listify by variable length

### DIFF
--- a/bids/modeling/tests/test_transformations.py
+++ b/bids/modeling/tests/test_transformations.py
@@ -170,7 +170,8 @@ def test_sum(collection):
 
 def test_scale(collection, sparse_run_variable_with_missing_values):
     transform.Scale(collection, variables=['RT', 'parametric gain'],
-                    output=['RT_Z', 'gain_Z'], groupby=['run', 'subject'])
+                    output=['RT_Z', 'gain_Z'], groupby=['run', 'subject'], 
+                    rescale=True)
     groupby = collection['RT'].get_grouper(['run', 'subject'])
     z1 = collection['RT_Z'].values
     z2 = collection['RT'].values.groupby(

--- a/bids/modeling/transformations/base.py
+++ b/bids/modeling/transformations/base.py
@@ -128,6 +128,9 @@ class Transformation(metaclass=ABCMeta):
             for k, v in self.kwargs.items():
                 if not isinstance(v, list):
                     self.kwargs[k] = [v] * len(self.variables)
+                elif not len(self.kwargs[k]) == len(self.variables):
+                    raise ValueError("Length of {} must match length of "
+                                     "variables".format(k))
 
         # Expand any detected variable group names or wild cards
         self._expand_variable_groups()

--- a/bids/modeling/transformations/base.py
+++ b/bids/modeling/transformations/base.py
@@ -122,11 +122,12 @@ class Transformation(metaclass=ABCMeta):
                 # 'variables'
                 kwargs[arg_spec.args[2 + i]] = arg_val
 
+        self.kwargs = kwargs
         # listify kwargs if synced
         if self._sync_kwargs:
-            self.kwargs = {k: listify(v) for k, v in kwargs.items()}
-        else:
-            self.kwargs = kwargs
+            for k, v in self.kwargs.items():
+                if not isinstance(v, list):
+                    self.kwargs[k] = [v] * len(self.variables)
 
         # Expand any detected variable group names or wild cards
         self._expand_variable_groups()


### PR DESCRIPTION
There was a small bug where is `sync_kwargs=True` for a transformation, but a non list argument was passed to the Transformation, it would be listified, but to be only lenght 1.

The `sync_kwargs` would later fail, because it's expecting a list of length `variables`. 