### PR TITLE
feat: bump formulaic max version constraint to include 0.5.x

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     scipy
     nibabel >=2.1
     pandas >=0.23
-    formulaic >=0.2.4, <0.4  # Tested on 0.2.4 and 0.3.2
+    formulaic >=0.2.4, <0.6
     sqlalchemy <1.4.0.dev0
     bids-validator
     num2words


### PR DESCRIPTION
Fixes #915