### PR TITLE
FIX: Address change in default pandas grouping behavior

### DIFF
--- a/bids/modeling/tests/test_transformations.py
+++ b/bids/modeling/tests/test_transformations.py
@@ -188,7 +188,7 @@ def test_scale(collection, sparse_run_variable_with_missing_values):
     groupby = collection['RT'].get_grouper(['run', 'subject'])
     z1 = collection['RT_Z'].values
     z2 = collection['RT'].values.groupby(
-        groupby).apply(lambda x: (x - x.mean()) / x.std())
+        groupby, group_keys=False).apply(lambda x: (x - x.mean()) / x.std())
     assert np.allclose(z1, z2)
 
     # Test constant input
@@ -231,8 +231,8 @@ def test_orthogonalize_dense(collection):
     vals = np.c_[rt.values, pg_pre.values, pg_post.values]
     df = pd.DataFrame(vals, columns=['rt', 'pre', 'post'])
     groupby = rt.get_grouper(['run', 'subject'])
-    pre_r = df.groupby(groupby).apply(lambda x: x.corr().iloc[0, 1])
-    post_r = df.groupby(groupby).apply(lambda x: x.corr().iloc[0, 2])
+    pre_r = df.groupby(groupby, group_keys=False).apply(lambda x: x.corr().iloc[0, 1])
+    post_r = df.groupby(groupby, group_keys=False).apply(lambda x: x.corr().iloc[0, 2])
     assert (pre_r > 0.2).any()
     assert (post_r < 0.0001).all()
 
@@ -246,8 +246,8 @@ def test_orthogonalize_sparse(collection):
     vals = np.c_[rt.values, pg_pre.values, pg_post.values]
     df = pd.DataFrame(vals, columns=['rt', 'pre', 'post'])
     groupby = collection['RT'].get_grouper(['run', 'subject'])
-    pre_r = df.groupby(groupby).apply(lambda x: x.corr().iloc[0, 1])
-    post_r = df.groupby(groupby).apply(lambda x: x.corr().iloc[0, 2])
+    pre_r = df.groupby(groupby, group_keys=False).apply(lambda x: x.corr().iloc[0, 1])
+    post_r = df.groupby(groupby, group_keys=False).apply(lambda x: x.corr().iloc[0, 2])
     assert (pre_r > 0.2).any()
     assert (post_r < 0.0001).all()
 

--- a/bids/variables/variables.py
+++ b/bids/variables/variables.py
@@ -199,7 +199,7 @@ class BIDSVariable(metaclass=ABCMeta):
             onto the function call.
         """
         grouper = self.get_grouper(groupby)
-        return self.values.groupby(grouper).apply(func, *args, **kwargs)
+        return self.values.groupby(grouper, group_keys=False).apply(func, *args, **kwargs)
 
     def to_df(self, condition=True, entities=True, **kwargs):
         """Convert to a DataFrame, with columns for name and entities.


### PR DESCRIPTION
Pre-release tests failing.

Pandas has been emitting this warning:

```
FutureWarning: Not prepending group keys to the result index of transform-like apply. In the future, the group keys will be included in the index, regardless of whether the applied function returns a like-indexed object.
  To preserve the previous behavior, use
  
  	>>> .groupby(..., group_keys=False)
  
  To adopt the future behavior and silence this warning, use 
  
  	>>> .groupby(..., group_keys=True)
```

Preserving old behavior fixes the issue. I haven't researched the issue to understand whether we should move to the new behavior and do something else...