### PR TITLE
FIX: Allowing custom BIDS configuration files for derivative datasets

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -139,9 +139,7 @@ class BIDSLayout(object):
             if description and description.get("DatasetType") == "derivative":
                 if validate:
                     validate_derivative_paths([root], self)
-                if config:
-                    config += ["bids", "derivatives"]
-                else:
+                if not config:
                     config = ["bids", "derivatives"]
 
             init_args = dict(root=root, absolute_paths=absolute_paths,

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -139,7 +139,10 @@ class BIDSLayout(object):
             if description and description.get("DatasetType") == "derivative":
                 if validate:
                     validate_derivative_paths([root], self)
-                config = ["bids", "derivatives"]
+                if config:
+                    config += ["bids", "derivatives"]
+                else:
+                    config = ["bids", "derivatives"]
 
             init_args = dict(root=root, absolute_paths=absolute_paths,
                              derivatives=derivatives, config=config)


### PR DESCRIPTION
Currently, if the root dataset is a derivative, initializing a `bids.layout.BIDSLayout` object will ignore anything set using `config` as it will always set the config to `["bids", "derivative"]` [as seen here.](https://github.com/bids-standard/pybids/blob/b3351dd25fa74801fa7033ce7e4046382520c461/bids/layout/layout.py#L142)

If a config file path is given to the creation of a `bids.layout.BIDSLayout` object, it should be used - especially in the case of a derivative dataset in which the default derivative BIDS configuration probably does not apply. 

The default `bids` and `derivatives` configurations should only be used if an alternate isn't provided.

Thank you @clin045 for pointing me in the right direction. 