### PR TITLE
FIX: Broken pattern matching

### DIFF
--- a/bids/cli.py
+++ b/bids/cli.py
@@ -136,7 +136,7 @@ def layout(
         validate=validate,
         config=config,
         indexer=BIDSLayoutIndexer(
-            valid_only=validate,
+            validate=validate,
             index_metadata=index_metadata,
             ignore=ignore,
             force_index=force_index,

--- a/bids/cli.py
+++ b/bids/cli.py
@@ -136,7 +136,7 @@ def layout(
         validate=validate,
         config=config,
         indexer=BIDSLayoutIndexer(
-            validate=validate,
+            valid_only=validate,
             index_metadata=index_metadata,
             ignore=ignore,
             force_index=force_index,

--- a/bids/layout/index.py
+++ b/bids/layout/index.py
@@ -71,14 +71,12 @@ class BIDSLayoutIndexer:
 
     Parameters
     ----------
-    valid_only : bool, optional
+    validate : bool, optional
         If True, all files are checked for BIDS compliance when first indexed,
         and non-compliant files are ignored. This provides a convenient way to
         restrict file indexing to only those files defined in the "core" BIDS
-        spec, as setting ``valid_only=True`` will lead noncompliant files
+        spec, as setting ``validate=True`` will lead noncompliant files
         like ``sub-01/nonbidsfile.txt`` to be ignored.
-    validate : bool, optional
-        Deprecated. Please use ``valid_only``.
     ignore : str or SRE_Pattern or list
         Path(s) to exclude from indexing. Each path is either a string or a
         SRE_Pattern object (i.e., compiled regular expression). If a string is
@@ -110,22 +108,13 @@ class BIDSLayoutIndexer:
 
     def __init__(
         self,
-        valid_only=None,
-        validate=None,
+        validate=False,
         ignore=None,
         force_index=None,
         index_metadata=True,
         config_filename='layout_config.json',
         **filters,
     ):
-        if validate is not None:
-            warnings.warn(
-                "The validate argument of BIDSLayoutIndexer is deprecated; "
-                "please set valid_only instead."
-            )
-
-        valid_only = valid_only if valid_only is not None else validate
-
         self.ignore = ignore
         self.force_index = force_index
         self.index_metadata = index_metadata
@@ -133,7 +122,7 @@ class BIDSLayoutIndexer:
         self.filters = filters
         self.validator = None
 
-        if valid_only or valid_only is None:
+        if validate:
             self.validator = BIDSValidator(index_associated=True)
 
         # Layout-dependent attributes to be set in __call__()

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -149,7 +149,7 @@ class BIDSLayout(object):
                 database_path, reset_database, config, init_args)
 
             if indexer is None:
-                indexer = BIDSLayoutIndexer(valid_only=validate, **indexer_kwargs)
+                indexer = BIDSLayoutIndexer(validate=validate, **indexer_kwargs)
             indexer(self)
 
         # Add derivatives if any are found

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -149,7 +149,7 @@ class BIDSLayout(object):
                 database_path, reset_database, config, init_args)
 
             if indexer is None:
-                indexer = BIDSLayoutIndexer(validate=validate, **indexer_kwargs)
+                indexer = BIDSLayoutIndexer(valid_only=validate, **indexer_kwargs)
             indexer(self)
 
         # Add derivatives if any are found
@@ -161,7 +161,7 @@ class BIDSLayout(object):
                 validate=validate, absolute_paths=absolute_paths,
                 derivatives=None, sources=self, config=None,
                 regex_search=regex_search, reset_database=reset_database,
-                indexer=indexer, **indexer_kwargs)
+                **indexer_kwargs)
 
     @property
     def root(self):
@@ -477,11 +477,13 @@ class BIDSLayout(object):
         kwargs['config'] = kwargs.get('config') or ['bids', 'derivatives']
         kwargs['sources'] = kwargs.get('sources') or self
 
+        # TODO: Derivatives cannot be validated
+        kwargs.pop("validate", None)
         for name, deriv in deriv_paths.items():
             if parent_database_path:
                 child_database_path = parent_database_path / name
                 kwargs['database_path'] = child_database_path
-            self.derivatives[name] = BIDSLayout(deriv, **kwargs)
+            self.derivatives[name] = BIDSLayout(deriv, validate=False, **kwargs)
 
     def to_df(self, metadata=False, **filters):
         """Return information for BIDSFiles tracked in Layout as pd.DataFrame.

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -408,7 +408,7 @@ def test_ignore_files(layout_ds005):
     # overrides the default - but 'model/extras/' should still be ignored
     # because of the regex.
     ignore = [re.compile('xtra'), 'dummy']
-    indexer = BIDSLayoutIndexer(valid_only=False, ignore=ignore)
+    indexer = BIDSLayoutIndexer(validate=False, ignore=ignore)
     layout2 = BIDSLayout(data_dir, indexer=indexer)
     assert target1 in layout2.files
     assert target2 not in layout2.files
@@ -435,7 +435,7 @@ def test_nested_include_exclude():
     layout = BIDSLayout(
         data_dir,
         indexer=BIDSLayoutIndexer(
-            valid_only=False,
+            validate=False,
             force_index=[os.path.join('models', 'extras')],
             ignore=['models'],
         ),
@@ -447,7 +447,7 @@ def test_nested_include_exclude():
     layout = BIDSLayout(
         data_dir,
         indexer=BIDSLayoutIndexer(
-            valid_only=False,
+            validate=False,
             force_index=[os.path.join('models', 'extras')],
             ignore=[re.compile('^/models/.+$')],
         ),
@@ -459,7 +459,7 @@ def test_nested_include_exclude():
     layout = BIDSLayout(
         data_dir,
         indexer=BIDSLayoutIndexer(
-            valid_only=False,
+            validate=False,
             force_index=['models'],
             ignore=[os.path.join('models', 'extras')],
         ),
@@ -471,7 +471,7 @@ def test_nested_include_exclude():
     layout = BIDSLayout(
         data_dir,
         indexer=BIDSLayoutIndexer(
-            valid_only=False,
+            validate=False,
             force_index=[re.compile('^/models/?$')],
             ignore=[os.path.join('models', 'extras')],
         ),
@@ -483,7 +483,7 @@ def test_nested_include_exclude():
     layout = BIDSLayout(
         data_dir,
         indexer=BIDSLayoutIndexer(
-            valid_only=False,
+            validate=False,
             force_index=['models', target2],
             ignore=[os.path.join('models', 'extras')],
         ),
@@ -495,7 +495,7 @@ def test_nested_include_exclude():
     layout = BIDSLayout(
         data_dir,
         indexer=BIDSLayoutIndexer(
-            valid_only=False,
+            validate=False,
             force_index=[os.path.join('models', 'extras')],
             ignore=[re.compile('^/models/.+$')],
         ),
@@ -507,7 +507,7 @@ def test_nested_include_exclude():
     layout = BIDSLayout(
         data_dir,
         indexer=BIDSLayoutIndexer(
-            valid_only=True,
+            validate=True,
             force_index=['models'],
             ignore=[os.path.join('models', 'extras')],
         ),
@@ -518,7 +518,7 @@ def test_nested_include_exclude():
     layout = BIDSLayout(
         data_dir,
         indexer=BIDSLayoutIndexer(
-            valid_only=True,
+            validate=True,
             force_index=[re.compile('^/models/?$')],
             ignore=[os.path.join('models', 'extras')],
         ),
@@ -529,7 +529,7 @@ def test_nested_include_exclude():
     layout = BIDSLayout(
         data_dir,
         indexer=BIDSLayoutIndexer(
-            valid_only=True,
+            validate=True,
             force_index=['models', target2],
             ignore=[os.path.join('models', 'extras')],
         ),
@@ -549,7 +549,7 @@ def test_nested_include_exclude_with_regex():
     layout = BIDSLayout(
         data_dir,
         indexer=BIDSLayoutIndexer(
-            valid_only=False,
+            validate=False,
             ignore=[patt2],
             force_index=[patt1],
         )
@@ -562,7 +562,7 @@ def test_nested_include_exclude_with_regex():
     layout = BIDSLayout(
         data_dir,
         indexer=BIDSLayoutIndexer(
-            valid_only=False,
+            validate=False,
             ignore=[patt1],
             force_index=[patt2],
         )
@@ -576,7 +576,7 @@ def test_nested_include_exclude_with_regex():
     layout = BIDSLayout(
         data_dir,
         indexer=BIDSLayoutIndexer(
-            valid_only=True,
+            validate=True,
             ignore=[patt2],
             force_index=[patt1],
         )
@@ -589,7 +589,7 @@ def test_nested_include_exclude_with_regex():
     layout = BIDSLayout(
         data_dir,
         indexer=BIDSLayoutIndexer(
-            valid_only=True,
+            validate=True,
             ignore=[patt1],
             force_index=[patt2],
         )

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -13,7 +13,7 @@ import pytest
 
 from bids.layout import BIDSLayout, Query
 from bids.layout.models import Config
-from bids.layout.index import BIDSLayoutIndexer, _check_path_matches_patterns
+from bids.layout.index import BIDSLayoutIndexer, _check_path_matches_patterns, _regexfy
 from bids.layout.utils import PaddedInt
 from bids.tests import get_test_data_path
 from bids.utils import natural_sort
@@ -48,9 +48,11 @@ def test_index_metadata(index_metadata, query, result, mock_config):
         indexer=BIDSLayoutIndexer(index_metadata=index_metadata),
         **query
     )
+
     sample_file = layout.get(task='rest', extension='.nii.gz',
-                             acquisition='fullbrain')[0]
-    metadata = sample_file.get_metadata()
+                             acquisition='fullbrain')
+    assert bool(sample_file)
+    metadata = sample_file[0].get_metadata()
     assert metadata.get('RepetitionTime') == result
 
 
@@ -169,7 +171,7 @@ class TestDerivativeAsRoot:
 
     def test_correctly_formatted_derivative_loads_as_derivative(self):
         dataset_path = Path("ds005_derivs", "dummy")
-        layout = BIDSLayout(Path(get_test_data_path())/dataset_path)
+        layout = BIDSLayout(Path(get_test_data_path())/dataset_path, validate=False)
         assert len(layout.get()) == 4
         assert len(layout.get(desc="preproc")) == 3
 
@@ -406,7 +408,7 @@ def test_ignore_files(layout_ds005):
     # overrides the default - but 'model/extras/' should still be ignored
     # because of the regex.
     ignore = [re.compile('xtra'), 'dummy']
-    indexer = BIDSLayoutIndexer(validate=False, ignore=ignore)
+    indexer = BIDSLayoutIndexer(valid_only=False, ignore=ignore)
     layout2 = BIDSLayout(data_dir, indexer=indexer)
     assert target1 in layout2.files
     assert target2 not in layout2.files
@@ -415,7 +417,7 @@ def test_ignore_files(layout_ds005):
 def test_force_index(layout_ds005):
     data_dir = join(get_test_data_path(), 'ds005')
     target = join(data_dir, 'models', 'ds-005_type-test_model.json')
-    indexer = BIDSLayoutIndexer(force_index=['models'])
+    indexer = BIDSLayoutIndexer(force_index=[re.compile('models(/.*)?')])
     model_layout = BIDSLayout(data_dir, validate=True, indexer=indexer)
     assert target not in layout_ds005.files
     assert target in model_layout.files
@@ -429,24 +431,48 @@ def test_nested_include_exclude():
     target1 = join(data_dir, 'models', 'ds-005_type-test_model.json')
     target2 = join(data_dir, 'models', 'extras', 'ds-005_type-test_model.json')
 
-    # Nest a directory inclusion within an exclusion
+    # Excluding a directory will disallow indexing further, even if forced
     layout = BIDSLayout(
         data_dir,
         indexer=BIDSLayoutIndexer(
-            validate=True,
+            valid_only=False,
             force_index=[os.path.join('models', 'extras')],
             ignore=['models'],
         ),
     )
     assert not layout.get_file(target1)
-    assert layout.get_file(target2)
+    assert not layout.get_file(target2)
 
-    # Nest a directory exclusion within an inclusion
+    # To nest patterns, we must allow searching within
     layout = BIDSLayout(
         data_dir,
         indexer=BIDSLayoutIndexer(
-            validate=True,
+            valid_only=False,
+            force_index=[os.path.join('models', 'extras')],
+            ignore=[re.compile('^/models/.+$')],
+        ),
+    )
+    assert not layout.get_file(target1)
+    assert layout.get_file(target2)
+
+    # Including a directory will disallow marking ignore subdirectories within
+    layout = BIDSLayout(
+        data_dir,
+        indexer=BIDSLayoutIndexer(
+            valid_only=False,
             force_index=['models'],
+            ignore=[os.path.join('models', 'extras')],
+        ),
+    )
+    assert layout.get_file(target1)
+    assert layout.get_file(target2)
+
+    # To nest a directory exclusion within an inclusion, use regex
+    layout = BIDSLayout(
+        data_dir,
+        indexer=BIDSLayoutIndexer(
+            valid_only=False,
+            force_index=[re.compile('^/models/?$')],
             ignore=[os.path.join('models', 'extras')],
         ),
     )
@@ -457,7 +483,53 @@ def test_nested_include_exclude():
     layout = BIDSLayout(
         data_dir,
         indexer=BIDSLayoutIndexer(
-            validate=True,
+            valid_only=False,
+            force_index=['models', target2],
+            ignore=[os.path.join('models', 'extras')],
+        ),
+    )
+    assert layout.get_file(target1)
+    assert layout.get_file(target2)
+
+    # To nest patterns, we must allow searching within
+    layout = BIDSLayout(
+        data_dir,
+        indexer=BIDSLayoutIndexer(
+            valid_only=False,
+            force_index=[os.path.join('models', 'extras')],
+            ignore=[re.compile('^/models/.+$')],
+        ),
+    )
+    assert not layout.get_file(target1)
+    assert layout.get_file(target2)
+
+    # With the validator, these paths will not be valid anyways
+    layout = BIDSLayout(
+        data_dir,
+        indexer=BIDSLayoutIndexer(
+            valid_only=True,
+            force_index=['models'],
+            ignore=[os.path.join('models', 'extras')],
+        ),
+    )
+    assert layout.get_file(target1)
+    assert layout.get_file(target2)
+
+    layout = BIDSLayout(
+        data_dir,
+        indexer=BIDSLayoutIndexer(
+            valid_only=True,
+            force_index=[re.compile('^/models/?$')],
+            ignore=[os.path.join('models', 'extras')],
+        ),
+    )
+    assert not layout.get_file(target1)
+    assert not layout.get_file(target2)
+
+    layout = BIDSLayout(
+        data_dir,
+        indexer=BIDSLayoutIndexer(
+            valid_only=True,
             force_index=['models', target2],
             ignore=[os.path.join('models', 'extras')],
         ),
@@ -468,22 +540,59 @@ def test_nested_include_exclude():
 
 def test_nested_include_exclude_with_regex():
     # ~same as above test, but use regexps instead of strings
-    patt1 = re.compile('.*dels$')
-    patt2 = re.compile('xtra')
+    patt1 = re.compile(r'.*dels/?$')
+    patt2 = re.compile(r'.*xtra.*')
     data_dir = join(get_test_data_path(), 'ds005')
     target1 = join(data_dir, 'models', 'ds-005_type-test_model.json')
     target2 = join(data_dir, 'models', 'extras', 'ds-005_type-test_model.json')
 
     layout = BIDSLayout(
         data_dir,
-        indexer=BIDSLayoutIndexer(ignore=[patt2], force_index=[patt1])
+        indexer=BIDSLayoutIndexer(
+            valid_only=False,
+            ignore=[patt2],
+            force_index=[patt1],
+        )
     )
     assert layout.get_file(target1)
     assert not layout.get_file(target2)
 
+    # If ignore matches a folder, it won't be indexed
+    patt1 = re.compile(r'.*dels/.+$')
     layout = BIDSLayout(
         data_dir,
-        indexer=BIDSLayoutIndexer(ignore=[patt1], force_index=[patt2])
+        indexer=BIDSLayoutIndexer(
+            valid_only=False,
+            ignore=[patt1],
+            force_index=[patt2],
+        )
+    )
+    assert not layout.get_file(target1)
+    assert layout.get_file(target2)
+
+    # With valid_only no path should be indexed under models/
+    patt1 = re.compile(r'.*dels/ds-005.*')
+    patt2 = re.compile(r'.*xtra.*')
+    layout = BIDSLayout(
+        data_dir,
+        indexer=BIDSLayoutIndexer(
+            valid_only=True,
+            ignore=[patt2],
+            force_index=[patt1],
+        )
+    )
+    assert layout.get_file(target1)
+    assert not layout.get_file(target2)
+
+    # If ignore matches a folder, it won't be indexed
+    patt1 = re.compile(r'.*dels/.+$')
+    layout = BIDSLayout(
+        data_dir,
+        indexer=BIDSLayoutIndexer(
+            valid_only=True,
+            ignore=[patt1],
+            force_index=[patt2],
+        )
     )
     assert not layout.get_file(target1)
     assert layout.get_file(target2)
@@ -877,8 +986,14 @@ def test_indexer_patterns(fname):
 
     assert bool(_check_path_matches_patterns(
         path,
-        ["code"],
-        root=None,
+        [_regexfy("code")],
+        root=root,
+    )) is (fname == "code")
+
+    assert bool(_check_path_matches_patterns(
+        path,
+        [_regexfy("code", root=root)],
+        root=root,
     )) is (fname == "code")
 
     assert _check_path_matches_patterns(

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -523,7 +523,7 @@ def test_nested_include_exclude():
             ignore=[os.path.join('models', 'extras')],
         ),
     )
-    assert not layout.get_file(target1)
+    assert layout.get_file(target1)
     assert not layout.get_file(target2)
 
     layout = BIDSLayout(

--- a/bids/layout/validation.py
+++ b/bids/layout/validation.py
@@ -31,11 +31,8 @@ EXAMPLE_DERIVATIVES_DESCRIPTION = {
 
 
 DEFAULT_LOCATIONS_TO_IGNORE = {
-    "code",
-    "stimuli",
-    "sourcedata",
-    "models",
-    re.compile(r'^\.'),
+    re.compile(r"^/(code|models|sourcedata|stimuli)"),
+    re.compile(r'/\.'),
 }
 
 def absolute_path_deprecation_warning():


### PR DESCRIPTION
## The problem
As indicated in #935, the pattern matching was pretty brittle, and did not take well sophisticated patterns.

## The solution
This PR converts string matching patterns into regexes (so only one type of pattern is tested, removed that if/else branch of the validation).

## Side effects
This PR makes several decisions that could be controversial:

* When a ``force_index`` or ``ignore``  pattern matches a folder, that's final. This is useful mostly for exclusions: marking a folder for ignore will not try to index any of its contents despite maybe having nested ``force_index``. The speedup in indexing of this decision is huge. If one still wants to have nested force/ignore, please check the new test cases in ``test_layout.py`` showing how to avoid a regex to exactly match the path of a folder (e.g., instead of `ignore=["models"]` you probably want to `ignore=[re.compile(r"models/.+")]` so that `/models/` is not entered for indexing.
* Revises the default patterns
* Deprecates the `validate` argument of `BIDSLayoutIndexer` in favor of `valid_only` as the dataset is not being validated, but rather you want to specify whether only BIDS-valid files should be returned.
* Accommodates the indexing of derivatives, forcing the generation of a new indexer every time.
* A side effect of the above is that fully invalid datasets will not be picked up as derivatives automatically. TBH, I don't know whether this was a feature or a bug.

## Other
* This PR is working with the regex example of #935 and dramatically speeds up the indexing by MRIQC.
* Happy to update whatever is not well received

Resolves: #935.