### PR TITLE
MNT: Require numpy 1.24 or lower for Python 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 ]
 dependencies = [
   "numpy",
+  "numpy <1.25.0.dev0; python_version < '3.9'",
   "scipy",
   "nibabel >=2.1",
   "pandas >=0.23",


### PR DESCRIPTION
Numpy 1.25.0.dev is breaking pre-release Python 3.8. They do not seem to be building wheels. We haven't dropped 3.8 yet (and it seems premature to), so just require numpy 1.24.x or lower for Py3.8.