### PR TITLE
Speed up BIDSLayout.get(return_type='id', ...)

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -533,7 +533,7 @@ class BIDSLayout(object):
             data.loc[o] = pd.Series(dtype=float)
 
         return data.reset_index()
-
+    
     def get(self, return_type='object', target=None, scope='all',
             regex_search=False, absolute_paths=None, invalid_filters='error',
             **filters):
@@ -676,7 +676,7 @@ class BIDSLayout(object):
             metadata = target not in self.get_entities(metadata=False)
 
             if return_type == 'id':
-                ent_iter = (x.get_entities(metadata=metadata) for x in results)
+                ent_iter = (x.entities for x in results)
                 results = list({
                     ents[target] for ents in ent_iter if target in ents
                 })

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -673,8 +673,6 @@ class BIDSLayout(object):
                 raise TargetError('If return_type is "id" or "dir", a valid '
                                  'target entity must also be specified.')
 
-            metadata = target not in self.get_entities(metadata=False)
-
             if return_type == 'id':
                 ent_iter = (x.entities for x in results)
                 results = list({

--- a/bids/layout/models.py
+++ b/bids/layout/models.py
@@ -312,6 +312,9 @@ class BIDSFile(Base):
             A dict, where keys are entity names and values are Entity
             instances.
         """
+        if metadata is None and values == 'tags':
+            return self.entities
+
         session = object_session(self)
         query = (session.query(Tag)
                  .filter_by(file_path=self.path)

--- a/bids/layout/tests/test_layout.py
+++ b/bids/layout/tests/test_layout.py
@@ -683,6 +683,9 @@ def test_get_tr(layout_7t_trt):
     tr = layout_7t_trt.get_tr(subject=['01', '02'], acquisition="prefrontal")
     assert tr == 4.0
 
+    tr = layout_7t_trt.get_RepetitionTime()
+    assert sum([t in tr for t in [3.0, 4.0]]) == 2
+
 
 def test_to_df(layout_ds117):
     # Only filename entities


### PR DESCRIPTION
Fixes #940 

The issue is that `BIDSFile.get_entities` is somewhat slow, because it has to do a SQL query. A single query is fine, but in this instance its doing it times the number of files in the result (which with no other argument, is the total number of files indexed).

Instead, I use `BIDSFile.entities`, which is much faster, because its an `association_proxy`. Essentially, instead of doing a complex query that filters, it just pulls all the entities for every file. 

This results in 36x speedup for `get_subjects` in my example dataset (660ms -> 18ms)

The crazy thing is this can be sped up even further, by doing a direct SQL query such as:
```
layout.session.query(models.Tag).filter_by(entity_name='subject').distinct().with_entities(models.Tag._value).all()
```
This only takes 2.14ms, which is over 300x faster.

The only issue is the latter query bypasses a lot of the Python logic built into pybids classes, which do somewhat important things such as formatting run ids as `PaddedInt` and ensuring the are returned in the correct type, so I was not able to use this implementation. 

On the whole, this makes me think that a lot of things that are "slow with pybids" need not be so...

