### PR TITLE
FIX: Exclude non-Hashables from set in .get(return_type='id')

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -674,13 +674,10 @@ class BIDSLayout(object):
                                  'target entity must also be specified.')
 
             if return_type == 'id':
-                u_results = set()
-                for f in results:
-                    if target in f.entities:
-                        val = f.entities[target]
-                        if isinstance(val, Hashable):
-                            u_results.add(val)
-                results = list(u_results)
+                results = list(dict.from_keys(
+                    res.entities[target] for res in results
+                    if target in res.entities and isinstance(res.entities[target], Hashable)
+                ))
 
             elif return_type == 'dir':
                 template = entities[target].directory

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -9,6 +9,7 @@ import copy
 import enum
 import difflib
 from pathlib import Path
+from typing import Hashable
 
 import sqlalchemy as sa
 from sqlalchemy.orm import aliased
@@ -673,10 +674,13 @@ class BIDSLayout(object):
                                  'target entity must also be specified.')
 
             if return_type == 'id':
-                ent_iter = (x.entities for x in results)
-                results = list({
-                    ents[target] for ents in ent_iter if target in ents
-                })
+                u_results = set()
+                for f in results:
+                    if target in f.entities:
+                        val = f.entities[target]
+                        if isinstance(val, Hashable):
+                            u_results.add(val)
+                results = list(u_results)
 
             elif return_type == 'dir':
                 template = entities[target].directory

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -674,7 +674,7 @@ class BIDSLayout(object):
                                  'target entity must also be specified.')
 
             if return_type == 'id':
-                results = list(dict.from_keys(
+                results = list(dict.fromkeys(
                     res.entities[target] for res in results
                     if target in res.entities and isinstance(res.entities[target], Hashable)
                 ))


### PR DESCRIPTION
Fixing a bug I introduced in #942 

The problem is that just getting the raw `.entities` variable from a `BIDSFile` will return everything, including meta-data (which is arguably a design flaw). 

The problem if anywhere in the meta-data you use the same name as a BIDS entity (in my case it was `task`), its returns will also be returned. 

This simple fix check if at least the input to `set` is not Hashable, to prevent an error (although it will still return something funky if a non-hashable result from meta-data sneaks in). 