### PR TITLE
ENH: Use pure SQL for return_type = 'id' queries

### DIFF
--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -9,6 +9,7 @@ import copy
 import enum
 import difflib
 from pathlib import Path
+from typing import Hashable
 
 import sqlalchemy as sa
 from sqlalchemy.orm import aliased
@@ -673,10 +674,13 @@ class BIDSLayout(object):
                                  'target entity must also be specified.')
 
             if return_type == 'id':
-                ent_iter = (x.entities for x in results)
-                results = list({
-                    ents[target] for ents in ent_iter if target in ents
-                })
+                u_results = set()
+                for f in results:
+                    if target in f.entities:
+                        val = f.entities[target]
+                        if isinstance(val, Hashable):
+                            u_results.add(val)
+                results = list(u_results)
 
             elif return_type == 'dir':
                 template = entities[target].directory

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -657,9 +657,11 @@ class BIDSLayout(object):
 
             _res = set()
             for sq in results:
-                _res.union(
-                    self.session.query(Tag._value).filter(
-                    Tag.file_path.in_(sq)).filter_by(entity_name=target).distinct().all()
+                q = self.session.query(Tag._value).filter(
+                    Tag.file_path.in_(sq)).filter_by(entity_name=target).distinct()
+
+                _res.update(
+                    [x[0] for x in q.all()]
                 )
 
             return natural_sort(list(_res))

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -646,7 +646,7 @@ class BIDSLayout(object):
             query = l._build_file_query(filters=filters,
                                         regex_search=regex_search)
             if return_type == 'id':
-                results.append(query.with_entities('file_path').subquery())
+                results.append(query.with_entities('path').subquery())
             else:
                 results.extend(query.all())
 
@@ -664,7 +664,7 @@ class BIDSLayout(object):
                     [x[0] for x in q.all()]
                 )
 
-            return natural_sort(list(_res))
+            return list(_res)
 
         # Convert to relative paths if needed
         if absolute_paths is None:  # can be overloaded as option to .get


### PR DESCRIPTION
An alternative to #948 and #942 

Instead of relying on looping over entities, allow the core logic of `.get` to return a subquery, rather than  list of files.

This subquery can then be used to find the unique entities of a given target for a list files, in pure SQL.

This can a bit faster (22ms vs 6-7 ms on my test dataset w/ ~80 subs), which could make a difference on very large datasets.



