### PR TITLE
CI: Update parameters to gh-action-pypi-publish

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -42,8 +42,8 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
-          skip_existing: true
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
       - name: Upload to PyPI (on tags)
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
```
Input 'repository_url' has been deprecated with message: The inputs have been normalized to use kebab-case. Use `repository-url` instead.
Input 'skip_existing' has been deprecated with message: The inputs have been normalized to use kebab-case. Use `skip-existing` instead.
```

See https://github.com/pypa/gh-action-pypi-publish/pull/125.