### PR TITLE
Allow sqlalchemy before 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "nibabel >=2.1",
   "pandas >=0.23",
   "formulaic >=0.2.4, <0.6",  # Tested on 0.2.4-0.5.2
-  "sqlalchemy <1.4.0.dev0",
+  "sqlalchemy <2.0",
   "bids-validator",
   "num2words",
   "click >=8.0",


### PR DESCRIPTION
Originally it was pinned this way in
17db82490f2930ec805da36d39ae7be09befb316
but no clear indication was recorded on why that is needed. If sqlalchemy really follows semver then it should remain comaptible with all the way to 2.0 .

Otherwise - it makes pybids not installable in an env which actually requires newer sqlalchemy (more plausing) like in our case see https://github.com/datalad/datalad-registry/issues/141#issuecomment-1480253580