### PR TITLE
CI: fix errors caused by changes in examples

### DIFF
--- a/bids/layout/tests/test_layout_on_examples.py
+++ b/bids/layout/tests/test_layout_on_examples.py
@@ -17,13 +17,13 @@ from bids.layout import BIDSLayout
 @pytest.mark.parametrize(
     "dataset, nb_files",
     [
-        ("qmri_irt1", 16),
+        ("qmri_irt1", 17),
         ("qmri_mese", 74),
-        ("qmri_mp2rage", 15),
+        ("qmri_mp2rage", 16),
         ("qmri_mp2rageme", 29),
-        ("qmri_mtsat", 24),
+        ("qmri_mtsat", 26),
         ("qmri_sa2rage", 10),
-        ("qmri_vfa", 18),
+        ("qmri_vfa", 19),
         ("qmri_mpm", 126),
         ("qmri_qsm", 9),
     ],
@@ -49,7 +49,7 @@ def test_layout_on_examples_with_derivatives(dataset, nb_files, bids_examples):
         ("pet003", 9),
         ("pet004", 10),
         ("pet005", 14),
-        ("qmri_megre", 18),
+        ("qmri_megre", 19),
         ("qmri_tb1tfl", 6),
     ],
 )


### PR DESCRIPTION
Before https://github.com/bids-standard/bids-examples/commit/36ab2fffc3da7f17bb9df02a9fcbe00ff019a1a0 / https://github.com/bids-standard/bids-examples/pull/337:
```sh
$ find qmri_irt1 -type f | wc -l
16
$ 
$ find qmri_mp2rage -type f | wc -l
15
$ 
$ find qmri_mtsat -type f | wc -l
24
$ 
$ find qmri_megre -type f | wc -l
18
$ 
$ find qmri_vfa -type f | wc -l
18
$ 
```

After https://github.com/bids-standard/bids-examples/commit/36ab2fffc3da7f17bb9df02a9fcbe00ff019a1a0 / https://github.com/bids-standard/bids-examples/pull/337:
```sh
$ find qmri_irt1 -type f | wc -l
17
$ 
$ find qmri_mp2rage -type f | wc -l
16
$ 
$ find qmri_mtsat -type f | wc -l
26
$ 
$ find qmri_megre -type f | wc -l
19
$ 
$ find qmri_vfa -type f | wc -l
19
$ 
```