### PR TITLE
BIDSVariables: Speed up Sparse to Dense

### DIFF
--- a/bids/variables/variables.py
+++ b/bids/variables/variables.py
@@ -504,6 +504,13 @@ class DenseRunVariable(BIDSVariable):
 
         index = []
         _timestamps = []
+        def _create_index_df(vals, col_names, repeats):
+            df = pd.DataFrame(np.zeros((repeats, len(col_names))), columns=col_names)
+            for i, val in enumerate(vals):
+                df[col_names[i]] = val
+
+            return df
+
         for run in run_info:
             if match_vol:
                 # If TR, fix reps to n_vols to ensure match
@@ -513,6 +520,7 @@ class DenseRunVariable(BIDSVariable):
 
             interval = int(round(1000. / sampling_rate))
             ent_vals = list(run.entities.values())
+            # import pdb; pdb.set_trace()
             df = pd.DataFrame([ent_vals] * reps, columns=list(run.entities.keys()))
             ts = pd.date_range(0, periods=len(df), freq='%sms' % interval)
             _timestamps.append(ts.to_series())

--- a/bids/variables/variables.py
+++ b/bids/variables/variables.py
@@ -245,16 +245,16 @@ class BIDSVariable(metaclass=ABCMeta):
             return (a[0] == a).all()
 
         constant = self.index.apply(is_unique)
-        if (constant == True).sum() == 0:
+        if constant.empty:
             return {}
         else:
             keep = self.index.columns[constant]
+            first_row_ix = self.index.index[0]
             res = {}
             for k in keep:
-                col = self.index[k]
-                v = col.iloc[0]
+                v = self.index.loc[first_row_ix, k]
                 if pd.isna(v): # Only drop NaNs if we get that on first try
-                    v = col.dropna().iloc[0]
+                    v = self.index[k].dropna().iloc[0]
                 res[k] = v
             return res
 

--- a/bids/variables/variables.py
+++ b/bids/variables/variables.py
@@ -405,6 +405,8 @@ class SparseRunVariable(SimpleVariable):
         # result in a nasty loss of precision in the resampling step.
         if sampling_rate is not None:
             bin_sr = max(bin_sr, sampling_rate)
+        else:
+            sampling_rate = bin_sr
 
         duration = int(math.ceil(bin_sr * self.get_duration()))
         ts = np.zeros(duration, dtype=self.values.dtype)
@@ -426,7 +428,7 @@ class SparseRunVariable(SimpleVariable):
             ts[_onset:_offset] = val
             last_ind = onsets[i]
 
-        if sampling_rate is not None and bin_sr != sampling_rate:
+        if bin_sr != sampling_rate:
             # Resample the time series to the requested sampling rate
             num = int(math.ceil(duration * sampling_rate / bin_sr))
             ts = _resample(ts, sampling_rate, bin_sr, num)
@@ -474,13 +476,16 @@ class DenseRunVariable(BIDSVariable):
     source : {'events', 'physio', 'stim', 'regressors', 'scans', 'sessions', 'participants', 'beh'}
         The type of BIDS variable file the data were extracted from.
     sampling_rate : :obj:`float`
-        Optional sampling rate (in Hz) to use. Must match the sampling rate used
-        to generate the values. If None, the collection's sampling rate will be used.
+        Mandatory sampling rate (in Hz) to use. Must match the sampling rate used
+        to generate the values. 
     """
 
     def __init__(self, name, values, run_info, source, sampling_rate):
 
         values = pd.DataFrame(values)
+
+        if not isinstance(sampling_rate, (float, int)):
+            raise TypeError("sampling_rate must be a float or integer, not %s" % type(sampling_rate))
 
         if hasattr(run_info, 'duration'):
             run_info = [run_info]


### PR DESCRIPTION
Various improvements to increase the speed of converting Sparse to Dense variables by an order of magnitude.

The previous approach was to:

1) First upsample the variable (potentially really high if the events have high temporal frequency)
2) Create an upsampled `DenseRunVariable`
3) resample to the desired (e.g. TR) sampling rate

The issue is that `DenseRunVariable.__init__` is somewhat slow. And much of what is done in `__init__` (bulding index) gets redone upon resample. 

I made several improvements to `__init__`, but in the end what was most imapctful was to abstract out the resampling logic, and apply it directly to the upsampled timecourse prior to creating a `DenseRunVariable`. Thus, once `DenseRunVariable.__init__` is run, it's on lower frequency data, and thus much faster.

For me, with ~20 high frequency variables, this speeds up the process from about ~28 to 2.4s