### PR TITLE
Drop Python 3.7 EOL

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest']
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10"]
         install: ['pip']
         check: ['ci_tests']
         pip-flags: ['']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "pybids"
 description = "bids: interface with datasets conforming to BIDS"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = { file="LICENSE" }
 authors = [
   { name = "PyBIDS Developers", email = "bids-discussion@googlegroups.com" },


### PR DESCRIPTION
Following NEP 29, dropping Python 3.7 support