### PR TITLE
CI: Use OIDC publishing instead of tokens

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -17,6 +17,9 @@ jobs:
   package:
     # Build packages and upload
     runs-on: ${{ matrix.os }}
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
     strategy:
       matrix:
         include:
@@ -40,13 +43,7 @@ jobs:
       - name: Test PyPI upload
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
-          skip-existing: true
       - name: Upload to PyPI (on tags)
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Giving https://docs.pypi.org/trusted-publishers/ a try. Since we push to test.pypi.org, this is a good package to try it on.