### PR TITLE
FIX: Drop JSON sidecar fields with null values during metadata indexing

### DIFF
--- a/bids/layout/index.py
+++ b/bids/layout/index.py
@@ -465,6 +465,10 @@ class BIDSLayoutIndexer:
 
             # Create Tag <-> Entity mappings, and any newly discovered Entities
             for md_key, md_val in file_md.items():
+                # Treat null entries (deserialized to None) as absent
+                # Alternative is to cast None to null in layout.models._create_tag_dict
+                if md_val is None:
+                    continue
                 tag_string = '{}_{}'.format(bf.path, md_key)
                 # Skip pairs that were already found in the filenames
                 if tag_string in all_tags:

--- a/bids/tests/data/ds005/task-mixedgamblestask_bold.json
+++ b/bids/tests/data/ds005/task-mixedgamblestask_bold.json
@@ -1,5 +1,6 @@
 {
     "RepetitionTime": 2.0,
     "TaskName": "mixed-gambles task",
-    "SliceTiming": [0.0, 0.0571, 0.1143, 0.1714, 0.2286, 0.2857]
+    "SliceTiming": [0.0, 0.0571, 0.1143, 0.1714, 0.2286, 0.2857],
+    "NullTestMetadata": null
 }


### PR DESCRIPTION
Starting by reproducing #1015.

Either need to encode `None`s as JSON `null`s or skip adding tags for them. My inclination is skip.

Fixes #1015.