### PR TITLE
MNT: Add Python 3.12 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest']
-        python-version: [3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
         dependencies: ['full', 'pre']
         include:
           - os: ubuntu-latest

--- a/bids/variables/variables.py
+++ b/bids/variables/variables.py
@@ -408,7 +408,9 @@ class SparseRunVariable(SimpleVariable):
         else:
             sampling_rate = bin_sr
 
-        duration = int(math.ceil(bin_sr * self.get_duration()))
+        duration = math.ceil(  # Round up to nearest second
+            round(bin_sr * self.get_duration(), 3)  # Cut off at millisecond precision
+        )
         ts = np.zeros(duration, dtype=self.values.dtype)
 
         onsets = np.round(self.onset * bin_sr).astype(int)


### PR DESCRIPTION
Builds on #1055, fixes one small bug and removes an import of the deprecated (and removed from default installations) `pkg_resources`.