### PR TITLE
REL: 0.16.5

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -44,6 +44,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
       - name: Upload to PyPI (on tags)
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.mailmap
+++ b/.mailmap
@@ -5,6 +5,7 @@ Alexander Ivanov <alexander.radievich@gmail.com>
 Alexis Thual <alexisthual@gmail.com>
 Ankur Sinha <sanjay.ankur@gmail.com>
 Antonin Rovai <81312414+arovai@users.noreply.github.com>
+Basile Pinsard <basile.pinsard@gmail.com>
 Bertrand Thirion <bertrand.thirion@inria.fr>
 Christopher J. Markiewicz <markiewicz@stanford.edu>
 Christopher J. Markiewicz <markiewicz@stanford.edu> <effigies@gmail.com>

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -176,6 +176,11 @@
       "orcid": "0000-0001-8421-365X"
     },
     {
+      "affiliation": "Child Mind Institute",
+      "name": "Erkent, Alp",
+      "orcid": "0000-0002-8820-4782"
+    },
+    {
       "affiliation": "Université de Sherbrooke",
       "name": "Legarreta, Jon Haitz",
       "orcid": "0000-0002-9661-1396"
@@ -224,6 +229,11 @@
       "name": "Thual, Alexis"
     },
     {
+      "affiliation": "University of Montréal, Montréal, Canada",
+      "name": "Pinsard, Basile",
+      "orcid": "0000-0002-4391-3075"
+    },
+    {
       "affiliation": "Berkeley Institute for Data Science; University of California at Berkeley",
       "name": "Holdgraf, Chris",
       "orcid": "0000-0002-2391-0678"
@@ -241,6 +251,10 @@
       "affiliation": "Brigham and Women's Hospital",
       "name": "Drew, William",
       "orcid": "0000-0002-9178-8731"
+    },
+    {
+      "name": "Khan, Ali",
+      "orcid": "0000-0002-0760-8647"
     },
     {
       "affiliation": "University College London",

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,27 @@
 Changelog
 =========
 
+Version 0.16.5 (May 22, 2024)
+-----------------------------
+
+Bug-fix release in the 0.16.x series.
+
+This release includes minor fixes, but reworks the testing
+infrastructure and resolves Python 3.12 incompatibilities.
+
+* FIX: Handle FileNotFoundError in BIDSLayout init when is_derivative=True and validate=False (#1049)
+* FIX: Add dwi root sbref, missing dwi entities to path patterns (#1059)
+* ENH: Update indexer to treat .zarr as files not dirs (#1046)
+* DOC: Deal with several warnings and errors in the doc build (#1061)
+* TST: Add bids-examples tests to cover ieeg, eeg, dwi (#1060)
+* MNT: Add Python 3.12 support (#1057)
+* MNT: Use tox to simplify testing environment setup (#1055)
+* MNT: Bump codecov/codecov-action from 3 to 4 (#1041)
+* MNT: Bump bids-examples from `1a000d6` to `eff47f1` (#1039)
+* MNT: Bump bids-examples from `b6e5234` to `1a000d6` (#1038)
+* MNT: Bump actions/upload-artifact from 3 to 4 (#1037)
+* MNT: Bump actions/setup-python from 4 to 5 (#1036)
+
 Version 0.16.4 (November 30, 2023)
 ----------------------------------
 


### PR DESCRIPTION
Release prep for 0.16.5. As indicated by the patch increment, I think the changes over 0.16.5 (https://github.com/bids-standard/pybids/compare/0.16.4...rel/0.16.5) are minimal, but they have accumulated.

@bpinsard @akhanf @alperkent I've added you to the Zenodo file, so you will be credited as authors in this and future releases. If you would prefer not to be let me know. If you would like to add ORCIDs or affiliations, let me know.

With sign-off, I'll release today. Without sign-off or objection, I'll release tomorrow.