### PR TITLE
ENH: pathlib -> universal_pathlib to enable cloud (and other filesystem) support

### DIFF
--- a/bids/config.py
+++ b/bids/config.py
@@ -1,7 +1,7 @@
 ''' Utilities for manipulating package-level settings. '''
 
 import json
-from pathlib import Path
+from upath import UPath as Path
 import os
 import warnings
 

--- a/bids/conftest.py
+++ b/bids/conftest.py
@@ -14,7 +14,7 @@ e.g.
 """
 
 import os
-from pathlib import Path
+from upath import UPath as Path
 from unittest.mock import patch
 
 import pytest

--- a/bids/layout/db.py
+++ b/bids/layout/db.py
@@ -2,7 +2,7 @@
 Database-related functionality.
 """
 
-from pathlib import Path
+from upath import UPath as Path
 import re
 import sqlite3
 from functools import lru_cache

--- a/bids/layout/index.py
+++ b/bids/layout/index.py
@@ -3,8 +3,9 @@
 import os
 import json
 import re
+import fsspec
 from collections import defaultdict
-from pathlib import Path
+from upath import UPath as Path
 from functools import partial, lru_cache
 
 from bids_validator import BIDSValidator
@@ -173,7 +174,7 @@ class BIDSLayoutIndexer:
 
         # BIDS validator expects absolute paths, but really these are relative
         # to the BIDS project root.
-        to_check = f.relative_to(self._layout._root)
+        to_check = Path(f.path).relative_to(Path(self._layout._root.path)) # use .path then Path() to drop the uri prefix
         # Pretend the path is an absolute path
         to_check = Path('/') / to_check
         # bids-validator works with posix paths only
@@ -202,8 +203,9 @@ class BIDSLayoutIndexer:
         for c in config:
             config_entities.update(c.entities)
 
+
         # Get lists of 1st-level subdirectories and files in the path directory
-        _, dirnames, filenames = next(os.walk(path))
+        _, dirnames, filenames = next(path.fs.walk(path.path))
 
         # Move any directories suffixed with .zarr to filenames
         zarrnames = [entry for entry in dirnames if Path(entry).suffix == '.zarr']
@@ -303,7 +305,7 @@ class BIDSLayoutIndexer:
         # if they correspond to data files that are indexed
         @lru_cache(maxsize=None)
         def load_json(path):
-            with open(path, 'r', encoding='utf-8') as handle:
+            with Path(path).fs.open(Path(path).path, 'r', encoding='utf-8') as handle:
                 try:
                     return json.load(handle)
                 except (UnicodeDecodeError, json.JSONDecodeError) as e:
@@ -324,7 +326,7 @@ class BIDSLayoutIndexer:
 
                 payload = None
                 if ext == '.json':
-                    payload = partial(load_json, bf.path)
+                    payload = partial(load_json, bf)
                 else:
                     filenames.append(bf)
 
@@ -496,3 +498,4 @@ class BIDSLayoutIndexer:
         self.session.bulk_save_objects(all_objs)
         self.session.bulk_insert_mappings(Tag, all_tag_dicts)
         self.session.commit()
+

--- a/bids/layout/layout.py
+++ b/bids/layout/layout.py
@@ -7,7 +7,7 @@ import json
 import copy
 import enum
 import difflib
-from pathlib import Path
+from upath import UPath as Path
 import warnings
 from typing import Hashable
 

--- a/bids/layout/models.py
+++ b/bids/layout/models.py
@@ -3,6 +3,7 @@
 import re
 import os
 from pathlib import Path
+from upath import UPath
 import warnings
 import json
 from copy import deepcopy
@@ -63,11 +64,11 @@ class LayoutInfo(Base):
     def _sanitize_init_args(self, kwargs):
         """ Prepare initialization arguments for serialization """
         if 'root' in kwargs:
-            kwargs['root'] = str(Path(kwargs['root']).absolute())
+            kwargs['root'] = str(UPath(kwargs['root']).absolute())
 
         if 'config' in kwargs and isinstance(kwargs['config'], list):
             kwargs['config'] = [
-                str(Path(config).absolute())
+                str(UPath(config).absolute())
                 if isinstance(config, os.PathLike) else config
                 for config in kwargs['config']
             ]
@@ -75,7 +76,7 @@ class LayoutInfo(Base):
         # Get abspaths
         if kwargs.get('derivatives') not in (None, True, False):
             kwargs['derivatives'] = [
-                str(Path(der).absolute())
+                str(UPath(der).absolute())
                 for der in listify(kwargs['derivatives'])
                 ]
 
@@ -157,11 +158,11 @@ class Config(Base):
         A Config instance.
         """
 
-        if isinstance(config, (str, Path)):
+        if isinstance(config, (str, Path, UPath)):
             config_paths = get_option('config_paths')
             if config in config_paths:
                 config = config_paths[config]
-            if not Path(config).exists():
+            if not UPath(config).exists():
                 raise ValueError("{} is not a valid path.".format(config))
             else:
                 with open(config, 'r') as f:
@@ -213,11 +214,11 @@ class BIDSFile(Base):
 
     @property
     def _path(self):
-        return Path(self.path)
+        return UPath(self.path)
 
     @property
     def _dirname(self):
-        return Path(self.dirname)
+        return UPath(self.dirname)
 
     def __getattr__(self, attr):
         # Ensures backwards compatibility with old File_ namedtuple, which is
@@ -245,7 +246,7 @@ class BIDSFile(Base):
     def relpath(self):
         """Return path relative to layout root"""
         root = object_session(self).query(LayoutInfo).first().root
-        return str(Path(self.path).relative_to(root))
+        return str(UPath(self.path).relative_to(root))
 
     def get_associations(self, kind=None, include_parents=False):
         """Get associated files, optionally limiting by association kind.
@@ -370,7 +371,7 @@ class BIDSFile(Base):
         if self._path.is_absolute() or root is None:
             path = self._path
         else:
-            path = Path(root) / self._path
+            path = UPath(root) / self._path
 
         if not path.exists():
             raise ValueError("Target filename to copy/symlink (%s) doesn't "

--- a/bids/layout/utils.py
+++ b/bids/layout/utils.py
@@ -1,5 +1,5 @@
 """Miscellaneous layout-related utilities."""
-from pathlib import Path
+from upath import UPath as Path
 
 from .. import config as cf
 from ..utils import make_bidsfile, listify

--- a/bids/layout/validation.py
+++ b/bids/layout/validation.py
@@ -1,6 +1,6 @@
 """Functionality related to validation of BIDSLayouts and BIDS projects."""
 
-from pathlib import Path
+from upath import UPath as Path
 import json
 import re
 import warnings
@@ -65,7 +65,6 @@ def validate_root(root, validate):
                         "containing the BIDS dataset.")
 
     root = root.absolute()
-
     if not root.exists():
         raise ValueError("BIDS root does not exist: %s" % root)
 
@@ -83,7 +82,7 @@ def validate_root(root, validate):
     else:
         err = None
         try:
-            with open(target, 'r', encoding='utf-8') as desc_fd:
+            with target.fs.open(target.path, 'r', encoding='utf-8') as desc_fd:
                 description = json.load(desc_fd)
         except (UnicodeDecodeError, json.JSONDecodeError) as e:
             description = None

--- a/bids/layout/writing.py
+++ b/bids/layout/writing.py
@@ -9,7 +9,7 @@ import shutil
 from string import Formatter
 from itertools import product
 from ..utils import listify
-from pathlib import Path
+from upath import UPath as Path
 
 __all__ = ['build_path', 'write_to_file']
 

--- a/bids/utils.py
+++ b/bids/utils.py
@@ -2,7 +2,7 @@
 
 import re
 import os
-from pathlib import Path
+from upath import UPath as Path
 
 
 def listify(obj):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ dependencies = [
   "bids-validator>=1.11",  # Keep up-to-date to ensure support for recent modalities
   "num2words >=0.5.5",
   "click >=8.0",
+  "fsspec==2024.3.1",
+  "universal_pathlib==0.2.2",
+  "gcsfs==2024.3.1",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,7 @@ dependencies = [
   "bids-validator>=1.11",  # Keep up-to-date to ensure support for recent modalities
   "num2words >=0.5.5",
   "click >=8.0",
-  "fsspec==2024.3.1",
-  "universal_pathlib==0.2.2",
-  "gcsfs==2024.3.1",
+  "universal_pathlib >=0.2.2",
 ]
 dynamic = ["version"]
 

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,6 @@ from setuptools import setup
 import versioneer
 
 setup(
-    version=versioneer.get_version(),
+    version='0.16.5-dev',
     cmdclass=versioneer.get_cmdclass(),
 )

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,6 @@ from setuptools import setup
 import versioneer
 
 setup(
-    version='0.16.5-dev',
+    version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
 )


### PR DESCRIPTION
This PR makes a relatively small change to the code that enables pybids to parse any filesystem backend that is supported by universal_pathlib (which is a subset of those supported by fsspec), by dropping in UPath instead of Path.

The list of filesystems currently supported (from https://github.com/fsspec/universal_pathlib) is:
- `file:` Local filesystem
- `memory:` Ephemeral filesystem in RAM
- `az:`, `adl:`, `abfs:` and `abfss:` Azure Storage _(requires `adlfs`)_
- `data:` RFC 2397 style data URLs _(requires `fsspec>=2023.12.2`)_
- `github:` GitHub repository filesystem
- `http:` and `https:` HTTP(S)-based filesystem
- `hdfs:` Hadoop distributed filesystem
- `gs:` and `gcs:` Google Cloud Storage _(requires `gcsfs`)_
- `s3:` and `s3a:` AWS S3 _(requires `s3fs` to be installed)_
- `webdav`, `webdav+http:` and `webdav+https:` WebDAV-based filesystem on top of
  HTTP(S) _(requires `webdav4[fsspec]`)_

I realize there has been a previous spin-off to enable S3 support (https://github.com/nrdg/cloud_bids_layout) but that has been inactive for ~4 years, and the proposed solution here would do the job more seamlessly, by simply being able to consume paths that include a uri prefix to designate the filesystem (e.g. `s3://` or `gcs://`). There was also an issue raised to request S3 support a while back that became stale and was closed #45.

E.g. one specific use-cases this PR could enable is applying pybids directly to openneuro datasets using the s3 uri:
``` layout = BIDSLayout('s3://openneuro.org/ds005360') ```

Filenames from the layout could then be consumed by any tool that support fsspec (pandas, dask, etc). Note: it looks like nibabel supports loading image from URLs, but does not yet support fsspec (https://github.com/nipy/nibabel/issues/1029), so use-cases for nifti data might be limited currently. 

My personal use-case is for BIDS microscopy data with OME-Zarr datasets, to allow BIDS apps to consume them directly from the cloud (e.g. using Dask or Zarr libraries). 

Re: this PR, I believe it shouldn't change how pybids works if a prefix is not used (eg the tests currently pass), but someone more familiar with the pybids internals would have to confirm. 

Keen to hear what others think!