### PR TITLE
fix: Create indices with object dtype

### DIFF
--- a/bids/modeling/transformations/munge.py
+++ b/bids/modeling/transformations/munge.py
@@ -140,7 +140,7 @@ class Factor(Transformation):
         variableClass = var.__class__
 
         levels = np.sort(data['amplitude'].unique())
-        new_cols = pd.get_dummies(data['amplitude'], drop_first=False)[levels]
+        new_cols = pd.get_dummies(data['amplitude'], drop_first=False, dtype=float)[levels]
 
         if len(levels) > 1 and constraint in ('drop_one', 'mean_zero'):
             if ref_level is None:
@@ -156,7 +156,7 @@ class Factor(Transformation):
                 continue
             name = ''.join([var.name, sep, str(lev)])
             lev_data = data.copy()
-            lev_data['amplitude'] = new_cols[lev].astype(float)
+            lev_data['amplitude'] = new_cols[lev]
             args = [name, lev_data, var.source]
             if hasattr(var, 'run_info'):
                 args.insert(2, var.run_info)

--- a/bids/variables/collections.py
+++ b/bids/variables/collections.py
@@ -158,7 +158,14 @@ class BIDSVariableCollection:
         ent_cols = list(all_cols - {"condition", "amplitude", "onset", "duration"})
 
         if format == "long":
-            df = df.reset_index(drop=True).fillna(fillna)
+            with warnings.catch_warnings():
+                # This change in behavior doesn't affect our usage, so ignore warnings
+                # without setting a global config for Pandas.
+                # Short story: fillna used to downcast object to float64, but if it isn't
+                # already float64, we have non-float objects in the column, so we've never
+                # downcasted.
+                warnings.filterwarnings("ignore", message='no_silent_downcasting', category=FutureWarning)
+                df = df.reset_index(drop=True).fillna(fillna)
         else:
             # Rows in wide format can only be defined by combinations of level entities
             # plus (for run-level variables) onset and duration.

--- a/bids/variables/io.py
+++ b/bids/variables/io.py
@@ -272,8 +272,9 @@ def _load_time_variables(layout, dataset=None, columns=None, scan_length=None,
                             columns={'amplitude': 'amplitude_'})
                     warnings.warn(msg)
 
-                _data = _data.replace('n/a', np.nan)  # Replace BIDS' n/a
-                _data = _data.apply(pd.to_numeric, errors='ignore')
+                # Pandas already converts 'n/a' to NaN. Leaving this comment
+                # because we used to do it manually here.
+                # We also converted to numeric, but this is now irrelevant.
 
                 _cols = columns or list(set(_data.columns.tolist()) -
                                         {'onset', 'duration'})

--- a/bids/variables/variables.py
+++ b/bids/variables/variables.py
@@ -526,7 +526,7 @@ class DenseRunVariable(BIDSVariable):
 
         def _create_index(all_keys, all_reps, all_ents):
             all_keys = np.array(sorted(all_keys))
-            df = pd.DataFrame(np.zeros((sum(all_reps), len(all_keys))), columns=all_keys)
+            df = pd.DataFrame(np.zeros((sum(all_reps), len(all_keys)), dtype=object), columns=all_keys)
 
             prev_ix = 0
             for i, reps in enumerate(all_reps):


### PR DESCRIPTION
Pandas is currently generating `FutureWarning`s:

```
.../.venv/lib/python3.12/site-packages/bids/variables/variables.py:535: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise in a future error of pandas. Value 'False' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.
  df.iloc[prev_ix:prev_ix + reps, col_ix] = v
```

https://github.com/bids-standard/pybids/blob/03a1af5af925a62e2a036d70b80d32e25066fca4/bids/variables/variables.py#L527-L538

Debugging, the issue is that we're creating the dataframe with a `np.zeros()`, so `dtype=float`, but entities and metadata may be strings, lists, etc. Using `dtype=object` resolves this.