### PR TITLE
FIX: cloud paths checking against patterns

### DIFF
--- a/bids/layout/index.py
+++ b/bids/layout/index.py
@@ -187,11 +187,11 @@ class BIDSLayoutIndexer:
         return self.validator.is_bids(to_check)
 
     def _index_dir(self, path, config, force=None):
-
-        abs_path = self._layout._root / path
+        root_path = Path(self._layout._root.path) # drops the uri prefix if it is there
+        abs_path = root_path / Path(path.path).relative_to(root_path)
 
         # Derivative directories must always be added separately
-        if self._layout._root.joinpath('derivatives') in abs_path.parents:
+        if root_path.joinpath('derivatives') in abs_path.parents:
             return [], []
 
         config = list(config)  # Shallow copy
@@ -211,6 +211,7 @@ class BIDSLayoutIndexer:
 
         # Get lists of 1st-level subdirectories and files in the path directory
         _, dirnames, filenames = next(path.fs.walk(path.path))
+
 
         # Symbolic links are returned as filenames even if they point to directories
         # Temporary list to store symbolic links that need to be removed from filenames

--- a/bids/layout/index.py
+++ b/bids/layout/index.py
@@ -41,12 +41,17 @@ def _extract_entities(bidsfile, entities):
 
 def _check_path_matches_patterns(path, patterns, root=None):
     """Check if the path matches at least one of the provided patterns. """
+
     if not patterns:
         return False
 
     path = path.absolute()
     if root is not None:
-        path = Path("/") / path.relative_to(root)
+
+        if isinstance(path,Path):
+            path = Path("/") / Path(path.path).relative_to(Path(root.path))
+        else:
+            path = Path("/") / path.relative_to(root)
 
     # Path now can be downcast to str
     path = str(path)

--- a/bids/layout/tests/test_remote_bids.py
+++ b/bids/layout/tests/test_remote_bids.py
@@ -1,26 +1,24 @@
-""" Tests runs layout on bids examples and make sure all files are caught"""
+"""Tests runs layout on bids examples and make sure all files are caught"""
 
-""" TODO
-- add more 'vanilla' datasets
-- missing files in micr?
-"""
+# TODO
+# - add more 'vanilla' datasets
+# - missing files in micr?
 
 import pytest
+from upath import UPath
 
 from bids.layout import BIDSLayout
 
 # Values for the number of files by downloading dataset first
 
+
 @pytest.mark.parametrize(
     "dataset, nb_files",
     [
-        ("s3://openneuro.org/ds000102", 136),
+        (UPath("s3://openneuro.org/ds000102", anon=True), 136),
     ],
 )
 def test_layout_on_s3_datasets_no_derivatives(dataset, nb_files):
     layout = BIDSLayout(dataset)
     files = layout.get()
     assert len(files) == nb_files
-
-
-

--- a/bids/layout/tests/test_remote_bids.py
+++ b/bids/layout/tests/test_remote_bids.py
@@ -1,0 +1,26 @@
+""" Tests runs layout on bids examples and make sure all files are caught"""
+
+""" TODO
+- add more 'vanilla' datasets
+- missing files in micr?
+"""
+
+import pytest
+
+from bids.layout import BIDSLayout
+
+# Values for the number of files by downloading dataset first
+
+@pytest.mark.parametrize(
+    "dataset, nb_files",
+    [
+        ("s3://openneuro.org/ds000102", 136),
+    ],
+)
+def test_layout_on_s3_datasets_no_derivatives(dataset, nb_files):
+    layout = BIDSLayout(dataset)
+    files = layout.get()
+    assert len(files) == nb_files
+
+
+

--- a/bids/layout/tests/test_remote_bids.py
+++ b/bids/layout/tests/test_remote_bids.py
@@ -5,6 +5,7 @@
 # - missing files in micr?
 
 import pytest
+from botocore.exceptions import NoCredentialsError
 from upath import UPath
 
 from bids.layout import BIDSLayout
@@ -18,6 +19,7 @@ from bids.layout import BIDSLayout
         (UPath("s3://openneuro.org/ds000102", anon=True), 136),
     ],
 )
+@pytest.mark.xfail(raises=NoCredentialsError)
 def test_layout_on_s3_datasets_no_derivatives(dataset, nb_files):
     layout = BIDSLayout(dataset)
     files = layout.get()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ test = [
   "coverage[toml]",
   "altair",
   "pytest-xdist",
+  "s3fs" #for testing remote uri
 ]
 model_reports = [
   "jinja2",

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,6 @@ from setuptools import setup
 import versioneer
 
 setup(
-    version=versioneer.get_version(),
+    version="0.17.2-dev",
     cmdclass=versioneer.get_cmdclass(),
 )

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,6 @@ from setuptools import setup
 import versioneer
 
 setup(
-    version="0.17.2-dev",
+    version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
 )


### PR DESCRIPTION
The _check_path_matches_patterns function was failing for cloud (e.g. s3, gc3) URIs (added in #1074):

 1) the path.relative_to() function doesn't work for cloud URIs
(it just returns the original).
 2) combining Path('/') with the result of relative_to() now (ie since universal_pathlib > 0.2.3) throws
an error when using cloud paths. 

So if using universal_pathlib >0.2.3, any cloud URIs as bids datasets would throw an error message.

This fix drops the uri prefix by using .path, so that the regex check works as expected.

