### PR TITLE
Remove calls to root logger basicConfig

### DIFF
--- a/src/bids/reports/parameters.py
+++ b/src/bids/reports/parameters.py
@@ -9,7 +9,6 @@ from num2words import num2words
 
 from .utils import list_to_str, num_to_str, remove_duplicates
 
-logging.basicConfig()
 LOGGER = logging.getLogger("pybids.reports.parsing")
 
 

--- a/src/bids/reports/parsing.py
+++ b/src/bids/reports/parsing.py
@@ -9,7 +9,6 @@ from .. import __version__
 from ..utils import collect_associated_files
 from . import parameters
 
-logging.basicConfig()
 LOGGER = logging.getLogger("pybids.reports.parsing")
 
 

--- a/src/bids/reports/utils.py
+++ b/src/bids/reports/utils.py
@@ -5,7 +5,6 @@ methods section from a BIDS dataset.
 """
 import logging
 
-logging.basicConfig()
 LOGGER = logging.getLogger("pybids.reports.utils")
 
 


### PR DESCRIPTION
This PR removes the calls to `logging.basicConfig` in the reports module, addressing #1105 