### PR TITLE
chore: Use tox-uv to ease lower bound checking, test on Python 3.13

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest']
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         dependencies: ['full', 'pre']
         source: ['repo']
         include:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -112,7 +112,6 @@ jobs:
       - uses: codecov/codecov-action@v5
         if: ${{ always() }}
         with:
-          files: cov.xml
           token: ${{ secrets.CODECOV_TOKEN }}
 
   test-publish:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -93,6 +93,8 @@ jobs:
       - name: Extract sdist
         if: matrix.source == 'sdist'
         run: tar --strip-components=1 -xzf dist/*.tar.gz
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -102,8 +104,7 @@ jobs:
         run: python -c "import sys; print(sys.version)"
       - name: Install tox
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install tox tox-gh-actions
+          uv tool install tox --with=tox-uv --with=tox-gh-actions
       - name: Show tox config
         run: tox c
       - name: Run tox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ versionfile_build = "bids/_version.py"
 
 [tool.coverage.run]
 branch = true
-source = ["src/bids/*"]
+source = ["src/", "tests/"]
 omit = [
   "*/setup.py",
   "*/external/*",
@@ -99,5 +99,11 @@ omit = [
   "*/*version.py",
 ]
 
+[tool.coverage.paths]
+source = [
+  "src/bids",
+  "**/site-packages/bids",
+]
+
 [tool.coverage.report]
-include = ["src/bids/*"]
+include = ["src/", "tests/"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,13 +47,13 @@ doc = [
 ]
 plotting = ["graphviz"]
 test = [
-  "pytest >=3.3",
-  "pytest-cov",
-  "bsmschema",
-  "coverage[toml]",
-  "altair",
-  "pytest-xdist",
-  "s3fs" #for testing remote uri
+  "pytest >= 6",
+  "pytest-cov >= 2.11",
+  "bsmschema >= 0.1",
+  "coverage[toml] >= 5.2.1",
+  "altair >= 5",
+  "pytest-xdist >= 2.5",
+  "s3fs >= 2024" #for testing remote uri
 ]
 model_reports = [
   "jinja2",

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ requires =
   tox>=4
   tox-uv
 envlist =
-  py3{9,10,11,12}-{full,pre}
+  py3{9,10,11,12,13}-{full,pre}
   py39-min
 skip_missing_interpreters = true
 
@@ -14,6 +14,7 @@ python =
   3.10: py310
   3.11: py311
   3.12: py312
+  3.13: py313
 
 [gh-actions:env]
 DEPENDS =

--- a/tox.ini
+++ b/tox.ini
@@ -44,8 +44,8 @@ uv_resolution =
 
 commands =
   pytest --doctest-modules -v \
-    --cov src/bids --cov-report xml:cov.xml --cov-report term \
-    src/bids {posargs:-n auto}
+    --cov src -cov tests --cov-report xml:cov.xml --cov-report term \
+    src/ tests/ {posargs:-n auto}
 
 [testenv:docs]
 description = Build documentation site

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ uv_resolution =
 
 commands =
   pytest --doctest-modules -v \
-    --cov src -cov tests --cov-report xml:cov.xml --cov-report term \
+    --cov src -cov tests --cov-report xml --cov-report term \
     src/ tests/ {posargs:-n auto}
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 requires =
   tox>=4
+  tox-uv
 envlist =
   py3{9,10,11,12}-{full,pre}
   py39-min
@@ -38,16 +39,8 @@ pass_env =
   CLICOLOR
   CLICOLOR_FORCE
 extras = test
-deps =
-  min: numpy ==1.22
-  min: scipy ==1.8
-  min: nibabel ==4.0
-  min: pandas ==1.2.0
-  # Tested on 0.2.4-0.5.2
-  min: formulaic ==0.2.4
-  min: sqlalchemy ==1.3.16
-  min: num2words ==0.5.5
-  min: click ==8.0
+uv_resolution =
+  min: lowest-direct
 
 commands =
   pytest --doctest-modules -v \


### PR DESCRIPTION
This PR does the following:

* Adopts tox-uv as a speedup for constructing test environments and automatically calculating minimum versions.
  * This requires setting lower bounds on test dependencies, which is fine. We don't need to be very conservative with these. I just picked some that have worked with other projects I've updated recently and the most recent major versions of some others.
* ~~Adds the scipy nightly build package index so we'll see breakage coming with plenty of warning.~~ Deferred.
* Begins testing on 3.13, which is enabled because altair released a new minor version. This cherry-picks @Remi-Gau's #1093.
* Some cleanups to coverage. I added tests/ to coverage, even though it's currently only data, so that they'll get picked up if we ever add tests that we don't want installed there.