### PR TITLE
chore(ci): Add Windows test job

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -66,6 +66,10 @@ jobs:
             python-version: '3'
             dependencies: full
             source: 'sdist'
+          - os: windows-latest
+            python-version: '3.12'
+            dependencies: full
+            source: repo
         exclude:
           # Drop pre tests for SPEC-0-unsupported Python versions
           # See https://scientific-python.org/specs/spec-0000/


### PR DESCRIPTION
No idea how tied we are to posix. Probably pretty tightly, but there's no reason in principle it couldn't be undone.

xref #1111