### PR TITLE
ENH: Allow plus signs in labels

### DIFF
--- a/src/bids/layout/config/bids.json
+++ b/src/bids/layout/config/bids.json
@@ -3,58 +3,58 @@
     "entities": [
         {
             "name": "subject",
-            "pattern": "[/\\\\]+sub-([a-zA-Z0-9]+)",
+            "pattern": "[/\\\\]+sub-([a-zA-Z0-9+]+)",
             "directory": "{subject}"
         },
         {
             "name": "session",
-            "pattern": "[_/\\\\]+ses-([a-zA-Z0-9]+)",
+            "pattern": "[_/\\\\]+ses-([a-zA-Z0-9+]+)",
             "mandatory": false,
             "directory": "{subject}{session}"
         },
         {
             "name": "sample",
-            "pattern": "[_/\\\\]+sample-([a-zA-Z0-9]+)"
+            "pattern": "[_/\\\\]+sample-([a-zA-Z0-9+]+)"
         },
         {
             "name": "task",
-            "pattern": "[_/\\\\]+task-([a-zA-Z0-9]+)"
+            "pattern": "[_/\\\\]+task-([a-zA-Z0-9+]+)"
         },
         {
             "name": "tracksys",
-            "pattern": "[_/\\\\]+tracksys-([a-zA-Z0-9]+)"
+            "pattern": "[_/\\\\]+tracksys-([a-zA-Z0-9+]+)"
         },
         {
             "name": "acquisition",
-            "pattern": "[_/\\\\]+acq-([a-zA-Z0-9]+)"
+            "pattern": "[_/\\\\]+acq-([a-zA-Z0-9+]+)"
         },
         {
             "name": "nucleus",
-            "pattern": "[_/\\\\]+nuc-([a-zA-Z0-9]+)"
+            "pattern": "[_/\\\\]+nuc-([a-zA-Z0-9+]+)"
         },
         {
             "name": "volume",
-            "pattern": "[_/\\\\]+voi-([a-zA-Z0-9]+)"
+            "pattern": "[_/\\\\]+voi-([a-zA-Z0-9+]+)"
         },
         {
             "name": "ceagent",
-            "pattern": "[_/\\\\]+ce-([a-zA-Z0-9]+)"
+            "pattern": "[_/\\\\]+ce-([a-zA-Z0-9+]+)"
         },
         {
             "name": "staining",
-            "pattern": "[_/\\\\]+stain-([a-zA-Z0-9]+)"
+            "pattern": "[_/\\\\]+stain-([a-zA-Z0-9+]+)"
         },
         {
             "name": "tracer",
-            "pattern": "[_/\\\\]+trc-([a-zA-Z0-9]+)"
+            "pattern": "[_/\\\\]+trc-([a-zA-Z0-9+]+)"
         },
         {
             "name": "reconstruction",
-            "pattern": "[_/\\\\]+rec-([a-zA-Z0-9]+)"
+            "pattern": "[_/\\\\]+rec-([a-zA-Z0-9+]+)"
         },
         {
             "name": "direction",
-            "pattern": "[_/\\\\]+dir-([a-zA-Z0-9]+)"
+            "pattern": "[_/\\\\]+dir-([a-zA-Z0-9+]+)"
         },
         {
             "name": "run",
@@ -63,11 +63,11 @@
         },
         {
             "name": "proc",
-            "pattern": "[_/\\\\]+proc-([a-zA-Z0-9]+)"
+            "pattern": "[_/\\\\]+proc-([a-zA-Z0-9+]+)"
         },
         {
             "name": "modality",
-            "pattern": "[_/\\\\]+mod-([a-zA-Z0-9]+)"
+            "pattern": "[_/\\\\]+mod-([a-zA-Z0-9+]+)"
         },
         {
             "name": "echo",
@@ -91,11 +91,11 @@
         },
         {
             "name": "recording",
-            "pattern": "[_/\\\\]+recording-([a-zA-Z0-9]+)"
+            "pattern": "[_/\\\\]+recording-([a-zA-Z0-9+]+)"
         },
         {
             "name": "space",
-            "pattern": "[_/\\\\]+space-([a-zA-Z0-9]+)"
+            "pattern": "[_/\\\\]+space-([a-zA-Z0-9+]+)"
         },
         {
             "name": "chunk",
@@ -103,7 +103,7 @@
         },
         {
             "name": "suffix",
-            "pattern": "(?:^|[_/\\\\])([a-zA-Z0-9]+)\\.[^/\\\\]+$"
+            "pattern": "(?:^|[_/\\\\])([a-zA-Z0-9+]+)\\.[^/\\\\]+$"
         },
         {
             "name": "scans",

--- a/src/bids/layout/config/derivatives.json
+++ b/src/bids/layout/config/derivatives.json
@@ -3,31 +3,31 @@
     "entities": [
         {
             "name": "atlas",
-            "pattern": "atlas-([a-zA-Z0-9]+)"
+            "pattern": "atlas-([a-zA-Z0-9+]+)"
         },
         {
             "name": "roi",
-            "pattern": "roi-([a-zA-Z0-9]+)"
+            "pattern": "roi-([a-zA-Z0-9+]+)"
         },
         {
             "name": "label",
-            "pattern": "label-([a-zA-Z0-9]+)"
+            "pattern": "label-([a-zA-Z0-9+]+)"
         },
         {
             "name": "desc",
-            "pattern": "desc-([a-zA-Z0-9]+)"
+            "pattern": "desc-([a-zA-Z0-9+]+)"
         },
         {
             "name": "from",
-            "pattern": "(?:^|_)from-([a-zA-Z0-9]+).*xfm"
+            "pattern": "(?:^|_)from-([a-zA-Z0-9+]+).*xfm"
         },
         {
             "name": "to",
-            "pattern": "(?:^|_)to-([a-zA-Z0-9]+).*xfm"
+            "pattern": "(?:^|_)to-([a-zA-Z0-9+]+).*xfm"
         },
         {
             "name": "mode",
-            "pattern": "(?:^|_)mode-([a-zA-Z0-9]+).*xfm"
+            "pattern": "(?:^|_)mode-([a-zA-Z0-9+]+).*xfm"
         },
         {
             "name": "hemi",
@@ -35,19 +35,19 @@
         },
         {
             "name": "res",
-            "pattern": "res-([a-zA-Z0-9]+)"
+            "pattern": "res-([a-zA-Z0-9+]+)"
         },
         {
             "name": "den",
-            "pattern": "den-([a-zA-Z0-9]+)"
+            "pattern": "den-([a-zA-Z0-9+]+)"
         },
         {
             "name": "model",
-            "pattern": "model-([a-zA-Z0-9]+)"
+            "pattern": "model-([a-zA-Z0-9+]+)"
         },
         {
             "name": "subset",
-            "pattern": "subset-([a-zA-Z0-9]+)"
+            "pattern": "subset-([a-zA-Z0-9+]+)"
         }
     ],
 


### PR DESCRIPTION
Related to https://github.com/bids-standard/bids-specification/pull/1926.

Changes proposed:

- Add `+` signs to the regular expressions for label entities in the `bids` and `derivatives` config files.