### PR TITLE
fix: Copy entities dict before modifying run variable type

### DIFF
--- a/src/bids/modeling/tests/test_statsmodels.py
+++ b/src/bids/modeling/tests/test_statsmodels.py
@@ -12,6 +12,7 @@ import json
 from bids.modeling import BIDSStatsModelsGraph
 from bids.modeling.statsmodels import ContrastInfo, expand_wildcards
 from bids.layout import BIDSLayout
+from bids.layout.utils import PaddedInt
 from bids.tests import get_test_data_path
 from bids.variables import BIDSVariableCollection
 
@@ -42,6 +43,13 @@ def graph_nodummy():
     graph = BIDSStatsModelsGraph(layout, json_file)
     graph.load_collections(scan_length=480, subject=["01", "02"])
     return graph
+
+def test_load_collections_types(graph):
+    # Very narrow regression test that ensures that load_collections does not
+    # modify the types of entities in-place
+    layout = graph.layout
+    bold = layout.get(suffix="bold", extension="nii.gz")[0]
+    assert isinstance(bold.entities["run"], PaddedInt)
 
 @pytest.mark.skipif(not has_graphviz, reason="Test requires graphviz")
 def test_write_graph(graph, tmp_path):

--- a/src/bids/variables/io.py
+++ b/src/bids/variables/io.py
@@ -188,10 +188,13 @@ def _load_time_variables(layout, dataset=None, columns=None, scan_length=None,
     # Main loop over images
     for img_obj in images:
 
-        entities = img_obj.entities
         img_f = img_obj.path
 
-        # Run is not mandatory, but we need a default for proper indexing
+        # Run is not mandatory, but we need it to behave like an int and not
+        # a PaddedInt later when we call `dataset.get_nodes('run', select_on)`
+        # Without this, we would see "run ==02" in the query, which breaks
+        # pandas.
+        entities = img_obj.entities.copy()
         if 'run' in entities:
             entities['run'] = int(entities['run'])
 


### PR DESCRIPTION
This resolves a very particular bug, which may or may not be the last, related to losing the zero-padding when processing a dataset with fitlins.

It turns out that once you call `BIDSStatsModelsGraph.load_collections()`, you lose the `PaddedInt` type in the BIDSFile's entity dictionary. This is because we mutate the dictionary in-place. This PR copies the dict and improves the comments.

Starting with a test I can confirm failed before the fix was applied.