### PR TITLE
fix: Ensure dotfiles are always filtered

### DIFF
--- a/src/bids/layout/tests/conftest.py
+++ b/src/bids/layout/tests/conftest.py
@@ -1,4 +1,5 @@
 from os.path import join
+import shutil
 
 import pytest
 
@@ -101,3 +102,10 @@ def layout_synthetic(tests_dir, request, db_dir):
 def layout_synthetic_nodb(tests_dir, request, db_dir):
     path = tests_dir / 'data' / 'synthetic'
     return BIDSLayout(path, derivatives=True)
+
+
+@pytest.fixture
+def temporary_dataset(tmp_path, tests_dir):
+    path = tests_dir / 'data' / 'ds005'
+    shutil.copytree(path, tmp_path / 'ds005')
+    return tmp_path / 'ds005'

--- a/src/bids/layout/tests/test_layout.py
+++ b/src/bids/layout/tests/test_layout.py
@@ -1195,3 +1195,13 @@ def test_ignore_dotfiles(temporary_dataset):
     assert str(arbitrary_dotfile) not in layout.files
     assert str(ds_store) not in layout.files
     assert str(osx_companion_file) not in layout.files
+
+
+def test_empty_directory(temporary_dataset):
+    anat = temporary_dataset / 'sub-01' / 'anat'
+    shutil.rmtree(anat)
+    anat.mkdir()
+
+    layout = BIDSLayout(temporary_dataset)
+
+    assert layout.get(subject='01', datatype='anat') == []

--- a/src/bids/layout/validation.py
+++ b/src/bids/layout/validation.py
@@ -32,8 +32,11 @@ EXAMPLE_DERIVATIVES_DESCRIPTION = {
 
 DEFAULT_LOCATIONS_TO_IGNORE = {
     re.compile(r"^/(code|models|sourcedata|stimuli)"),
-    re.compile(r'/\.'),
 }
+
+ALWAYS_IGNORE = (
+    re.compile(r'/\.'),  # dotfiles should never be indexed
+)
 
 def absolute_path_deprecation_warning():
     warnings.warn("The absolute_paths argument will be removed from PyBIDS "
@@ -156,9 +159,11 @@ def _sort_patterns(patterns, root):
 
 def validate_indexing_args(ignore, force_index, root):
     if ignore is None:
-        ignore = list(
-            DEFAULT_LOCATIONS_TO_IGNORE - set(force_index or [])
-        )
+        ignore = DEFAULT_LOCATIONS_TO_IGNORE - set(force_index or [])
+
+    ignore = list(ignore)
+
+    ignore.extend(ALWAYS_IGNORE)
 
     # root has already been validated to be a directory
     ignore = _sort_patterns(ignore, root)


### PR DESCRIPTION
Dotfiles are ignored by default, but custom ignore patterns override the default ignores. This change ensures that dotfiles are always ignored in either case.

Regression test reproduces #1069 and patch fixes it.

Closes #1069.