### PR TITLE
fix: Catch StopIteration on directory walk

### DIFF
--- a/src/bids/layout/index.py
+++ b/src/bids/layout/index.py
@@ -208,10 +208,14 @@ class BIDSLayoutIndexer:
         for c in config:
             config_entities.update(c.entities)
 
-
         # Get lists of 1st-level subdirectories and files in the path directory
-        _, dirnames, filenames = next(path.fs.walk(path.path))
-
+        try:
+            _, dirnames, filenames = next(path.fs.walk(path.path))
+        except StopIteration:
+            # It's unclear when this gets hit, but tests will occasionally fail here.
+            # Hopefully this only occurs when we enter an empty directory,
+            # but even if not, there's nothing else to do in this case.
+            return [], []
 
         # Symbolic links are returned as filenames even if they point to directories
         # Temporary list to store symbolic links that need to be removed from filenames


### PR DESCRIPTION
We're occasionally getting failures like https://github.com/bids-standard/pybids/actions/runs/13679431654/job/38247759389

```
  =================================== FAILURES ===================================
  _________________________ test_layout_with_validation __________________________
  [gw1] linux -- Python 3.11.11 /home/runner/work/pybids/pybids/.tox/py311-pre/bin/python3
  
      def test_layout_with_validation():
          data_dir = join(get_test_data_path(), '7t_trt')
          layout1 = BIDSLayout(data_dir, validate=True)
  >       layout2 = BIDSLayout(data_dir, validate=False)
  
  src/bids/layout/tests/test_validation.py:21: 
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
  src/bids/layout/layout.py:177: in __init__
      _indexer(self)
  src/bids/layout/index.py:153: in __call__
      all_bfs, all_tag_dicts = self._index_dir(self._layout._root, self._config)
  src/bids/layout/index.py:260: in _index_dir
      dir_bfs, dir_tag_dicts = self._index_dir(d, config, force=force)
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
  
  self = <bids.layout.index.BIDSLayoutIndexer object at 0x7fe045d00950>
  path = PosixUPath('/home/runner/work/pybids/pybids/tests/data/7t_trt/sub-Bob')
  config = [<Config bids>], force = None
  
      def _index_dir(self, path, config, force=None):
          root_path = Path(self._layout._root.path) # drops the uri prefix if it is there
          abs_path = root_path / Path(path.path).relative_to(root_path)
      
          # Derivative directories must always be added separately
          if root_path.joinpath('derivatives') in abs_path.parents:
              return [], []
      
          config = list(config)  # Shallow copy
      
          # Check for additional config file in directory
          layout_file = self.config_filename
          config_file = abs_path / layout_file
          if config_file.exists():
              cfg = Config.load(config_file, session=self.session)
              config.append(cfg)
      
          # Track which entities are valid in filenames for this directory
          config_entities = {}
          for c in config:
              config_entities.update(c.entities)
      
      
          # Get lists of 1st-level subdirectories and files in the path directory
  >       _, dirnames, filenames = next(path.fs.walk(path.path))
  E       StopIteration
  
  src/bids/layout/index.py:213: StopIteration
  
  The above exception was the direct cause of the following exception:
  
  cls = <class '_pytest.runner.CallInfo'>
  func = <function call_and_report.<locals>.<lambda> at 0x7fe0463dea20>
  when = 'call'
  reraise = (<class '_pytest.outcomes.Exit'>, <class 'KeyboardInterrupt'>)
  
      @classmethod
      def from_call(
          cls,
          func: Callable[[], TResult],
          when: Literal["collect", "setup", "call", "teardown"],
          reraise: type[BaseException] | tuple[type[BaseException], ...] | None = None,
      ) -> CallInfo[TResult]:
          """Call func, wrapping the result in a CallInfo.
      
          :param func:
              The function to call. Called without arguments.
          :type func: Callable[[], _pytest.runner.TResult]
          :param when:
              The phase in which the function is called.
          :param reraise:
              Exception or exceptions that shall propagate if raised by the
              function, instead of being wrapped in the CallInfo.
          """
          excinfo = None
          start = timing.time()
          precise_start = timing.perf_counter()
          try:
  >           result: TResult | None = func()
  
  .tox/py311-pre/lib/python3.11/site-packages/_pytest/runner.py:341: 
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
  .tox/py311-pre/lib/python3.11/site-packages/_pytest/runner.py:242: in <lambda>
      lambda: runtest_hook(item=item, **kwds), when=when, reraise=reraise
  .tox/py311-pre/lib/python3.11/site-packages/pluggy/_hooks.py:513: in __call__
      return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  .tox/py311-pre/lib/python3.11/site-packages/pluggy/_manager.py:120: in _hookexec
      return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  .tox/py311-pre/lib/python3.11/site-packages/_pytest/threadexception.py:92: in pytest_runtest_call
      yield from thread_exception_runtest_hook()
  .tox/py311-pre/lib/python3.11/site-packages/_pytest/threadexception.py:68: in thread_exception_runtest_hook
      yield
  .tox/py311-pre/lib/python3.11/site-packages/_pytest/unraisableexception.py:95: in pytest_runtest_call
      yield from unraisable_exception_runtest_hook()
  .tox/py311-pre/lib/python3.11/site-packages/_pytest/unraisableexception.py:70: in unraisable_exception_runtest_hook
      yield
  .tox/py311-pre/lib/python3.11/site-packages/_pytest/logging.py:846: in pytest_runtest_call
      yield from self._runtest_for(item, "call")
  .tox/py311-pre/lib/python3.11/site-packages/_pytest/logging.py:829: in _runtest_for
      yield
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
  
  self = <CaptureManager _method='fd' _global_capturing=<MultiCapture out=<FDCapture 1 oldfd=7 _state='suspended' tmpfile=<_io....xtIOWrapper name='/dev/null' mode='r' encoding='utf-8'>> _state='suspended' _in_suspended=False> _capture_fixture=None>
  item = <Function test_layout_with_validation>
  
      @hookimpl(wrapper=True)
      def pytest_runtest_call(self, item: Item) -> Generator[None]:
          with self.item_capture("call", item):
  >           return (yield)
  E           RuntimeError: generator raised StopIteration
  
  .tox/py311-pre/lib/python3.11/site-packages/_pytest/capture.py:898: RuntimeError
```

I think this is a pytest-related heisenbug, but it is catchable and the correct thing to do is straightforward.

I initially prepared this patch for #925, but after writing the test, it looked like that bug was already solved. But then we got a CI failure that also needed it.