### PR TITLE
Pick the most specific sidecar when several match

### DIFF
--- a/src/bids/layout/index.py
+++ b/src/bids/layout/index.py
@@ -396,7 +396,8 @@ class BIDSLayoutIndexer:
             while True:
                 # Get JSON payloads
                 json_data = file_data.get(json_key, {}).get(dirname, [])
-                for js_ents, js_md, js_path in json_data:
+                # Most specific first, so the closest sidecar wins.
+                for js_ents, js_md, js_path in sorted(json_data, key=lambda d: -len(d[0])):
                     js_keys = set(js_ents.keys())
                     if js_keys - file_ent_keys:
                         continue

--- a/src/bids/layout/tests/test_layout.py
+++ b/src/bids/layout/tests/test_layout.py
@@ -937,6 +937,34 @@ def test_get_dataset_description(layout_ds005_multi_derivs):
     assert set([d['Name'] for d in dd]) == names
 
 
+def test_sidecar_matches_most_specific_entities(tmp_path):
+    """A file takes the sidecar sharing all its entities, not a less specific one.
+
+    Regression test for #1253: the part-phase image inherited the magnitude
+    image's sidecar because both matched and the less specific one came first.
+    """
+    func = tmp_path / 'sub-01' / 'func'
+    func.mkdir(parents=True)
+    (tmp_path / 'dataset_description.json').write_text(
+        json.dumps({'Name': 'sidecars', 'BIDSVersion': '1.8.0'})
+    )
+    stems = {
+        'sub-01_task-rest_bold': 'arbitrary',
+        'sub-01_task-rest_part-phase_bold': 'rad',
+    }
+    for stem, units in stems.items():
+        (func / f'{stem}.nii.gz').touch()
+        (func / f'{stem}.json').write_text(json.dumps({'Units': units}))
+
+    layout = BIDSLayout(tmp_path, validate=False)
+
+    for stem, units in stems.items():
+        img = layout.get_file(func / f'{stem}.nii.gz')
+        assert img.get_metadata()['Units'] == units
+        sidecars = [a.path for a in img.get_associations() if a.path.endswith('.json')]
+        assert sidecars == [str(func / f'{stem}.json')]
+
+
 def test_indexed_file_associations(layout_7t_trt):
     img = layout_7t_trt.get(
         subject='01',


### PR DESCRIPTION
Fixes #1253. When several sidecars match, the most specific one wins, so `part-phase` images no longer get the magnitude sidecar.
